### PR TITLE
Reduce memory allocations in Reader

### DIFF
--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -226,7 +226,7 @@ func (r *reader) Read(p []byte) (int, error) {
 		if err == io.EOF && r.compressionLeft == 0 {
 			return got, io.EOF
 		} else if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-			return got, fmt.Errorf("failed to read from underlying reader: %s", err)
+			return 0, fmt.Errorf("failed to read from underlying reader: %s", err)
 		}
 		src = src[:r.compressionLeft+n]
 


### PR DESCRIPTION
The reader has both decompressionBuffer and dstBuffer for buffering, seems that dstBuffer is duplicated, having decompressionBuffer should be enough.

Also, srcBuffer is not necessary.

We could reduced the memory allocation for them, also avoid the memory copying.