### PR TITLE
[travis] Add Go 1.10 to list of tested go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 os:
   - linux


### PR DESCRIPTION
As easy as the title: Run tests & benchmarks against Go 1.10