### PR TITLE
[zstd][errors] Get rid of static error code translation and use C call

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,34 @@
+package zstd
+
+/*
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+*/
+import "C"
+
+// ErrorCode is an error returned by the zstd library.
+type ErrorCode int
+
+func (e ErrorCode) Error() string {
+	a := C.ZSTD_getErrorName(C.size_t(e))
+	return C.GoString(a)
+}
+
+func cIsError(code int) bool {
+	return int(C.ZSTD_isError(C.size_t(code))) != 0
+}
+
+// getError returns an error for the return code, or nil if it's not an error
+func getError(code int) error {
+	if code < 0 && cIsError(code) {
+		return ErrorCode(code)
+	}
+	return nil
+}
+
+func IsDstSizeTooSmallError(e error) bool {
+	if e != nil && e.Error() == "Destination buffer is too small" {
+		return true
+	}
+	return false
+}

--- a/errors.go
+++ b/errors.go
@@ -9,9 +9,9 @@ import "C"
 // ErrorCode is an error returned by the zstd library.
 type ErrorCode int
 
+// Error returns the error string given by zstd
 func (e ErrorCode) Error() string {
-	a := C.ZSTD_getErrorName(C.size_t(e))
-	return C.GoString(a)
+	return C.GoString(C.ZSTD_getErrorName(C.size_t(e)))
 }
 
 func cIsError(code int) bool {

--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,7 @@ func getError(code int) error {
 	return nil
 }
 
+// IsDstSizeTooSmallError returns whether the error correspond to zstd standard sDstSizeTooSmall error
 func IsDstSizeTooSmallError(e error) bool {
 	if e != nil && e.Error() == "Destination buffer is too small" {
 		return true

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,24 @@
+package zstd
+
+import (
+	"testing"
+)
+
+const (
+	// ErrorUpperBound is the upper bound to error number, currently only used in test
+	// If this needs to be updated, check in zstd_errors.h what the max is
+	ErrorUpperBound = 1000
+)
+
+// TestFindIsDstSizeTooSmallError tests that there is at least one error code that
+// corresponds to dst size too small
+func TestFindIsDstSizeTooSmallError(t *testing.T) {
+	for i := -1; i > -ErrorUpperBound; i-- {
+		e := ErrorCode(i)
+		if IsDstSizeTooSmallError(e) {
+			return // Found
+		}
+	}
+
+	t.Fatal("Couldn't find an error code for DstSizeTooSmall error, please make sure we didn't change the error string")
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -13,12 +13,17 @@ const (
 // TestFindIsDstSizeTooSmallError tests that there is at least one error code that
 // corresponds to dst size too small
 func TestFindIsDstSizeTooSmallError(t *testing.T) {
+	found := 0
 	for i := -1; i > -ErrorUpperBound; i-- {
 		e := ErrorCode(i)
 		if IsDstSizeTooSmallError(e) {
-			return // Found
+			found++
 		}
 	}
 
-	t.Fatal("Couldn't find an error code for DstSizeTooSmall error, please make sure we didn't change the error string")
+	if found == 0 {
+		t.Fatal("Couldn't find an error code for DstSizeTooSmall error, please make sure we didn't change the error string")
+	} else if found > 1 {
+		t.Fatal("IsDstSizeTooSmallError found multiple error codes matching, this shouldn't be the case")
+	}
 }

--- a/zstd.go
+++ b/zstd.go
@@ -12,14 +12,16 @@ import (
 	"unsafe"
 )
 
+// Defines best and standard values for zstd cli
 const (
-	BestSpeed       = 1
-	BestCompression = 20
+	BestSpeed          = 1
+	BestCompression    = 20
+	DefaultCompression = 5
 )
 
 var (
-	ErrEmptySlice      = errors.New("Bytes slice is empty")
-	DefaultCompression = 5
+	// ErrEmptySlice is returned when there is nothing to compress
+	ErrEmptySlice = errors.New("Bytes slice is empty")
 )
 
 // CompressBound returns the worst case size needed for a destination buffer,

--- a/zstd.go
+++ b/zstd.go
@@ -12,53 +12,13 @@ import (
 	"unsafe"
 )
 
-// ErrorCode is an error returned by the zstd library.
-type ErrorCode int
-
-func (e ErrorCode) Error() string {
-	if C.ZSTD_isError(C.size_t(e)) != C.uint(0) {
-		return C.GoString(C.ZSTD_getErrorName(C.size_t(e)))
-	}
-
-	return ""
-}
-
 const (
 	BestSpeed       = 1
 	BestCompression = 20
 )
 
-// FIXME: this is very fragile, must map 1-to-1 with zstd's
-// error_public.h. They have no problem with adding error codes,
-// renumbering errors, etc.
 var (
-	ErrGeneric                           ErrorCode = -1
-	ErrPrefixUnknown                     ErrorCode = -2
-	ErrVersionUnsupported                ErrorCode = -3
-	ErrParameterUnknown                  ErrorCode = -4
-	ErrFrameParameterUnsupported         ErrorCode = -5
-	ErrFrameParameterUnsupportedBy32bits ErrorCode = -6
-	ErrFrameParameterWindowTooLarge      ErrorCode = -7
-	ErrCompressionParameterUnsupported   ErrorCode = -8
-	ErrCompressionParameterOutOfBound    ErrorCode = -9
-	ErrInitMissing                       ErrorCode = -10
-	ErrMemoryAllocation                  ErrorCode = -11
-	ErrStageWrong                        ErrorCode = -12
-	ErrDstSizeTooSmall                   ErrorCode = -13
-	ErrSrcSizeWrong                      ErrorCode = -14
-	ErrCorruptionDetected                ErrorCode = -15
-	ErrChecksumWrong                     ErrorCode = -16
-	ErrTableLogTooLarge                  ErrorCode = -17
-	ErrMaxSymbolValueTooLarge            ErrorCode = -18
-	ErrMaxSymbolValueTooSmall            ErrorCode = -19
-	ErrDictionaryCorrupted               ErrorCode = -20
-	ErrDictionaryWrong                   ErrorCode = -21
-	ErrDictionaryCreationFailed          ErrorCode = -22
-	ErrFrameIndexTooLarge                ErrorCode = -23
-	ErrSeekableIO                        ErrorCode = -24
-	ErrMaxCode                           ErrorCode = -25
-	ErrEmptySlice                                  = errors.New("Bytes slice is empty")
-
+	ErrEmptySlice      = errors.New("Bytes slice is empty")
 	DefaultCompression = 5
 )
 
@@ -77,18 +37,6 @@ func CompressBound(srcSize int) int {
 // cCompressBound is a cgo call to check the go implementation above against the c code.
 func cCompressBound(srcSize int) int {
 	return int(C.ZSTD_compressBound(C.size_t(srcSize)))
-}
-
-// getError returns an error for the return code, or nil if it's not an error
-func getError(code int) error {
-	if code < 0 && code > int(ErrMaxCode) {
-		return ErrorCode(code)
-	}
-	return nil
-}
-
-func cIsError(code int) bool {
-	return int(C.ZSTD_isError(C.size_t(code))) != 0
 }
 
 // Compress src into dst.  If you have a buffer to use, you can pass it to
@@ -161,7 +109,7 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	}
 	for i := 0; i < 3; i++ { // 3 tries to allocate a bigger buffer
 		result, err := decompress(dst, src)
-		if err != ErrDstSizeTooSmall {
+		if !IsDstSizeTooSmallError(err) {
 			return result, err
 		}
 		dst = make([]byte, len(dst)*2) // Grow buffer by 2


### PR DESCRIPTION
- Errors were defined in private C/header files and we needed to change them every release (FIXME: this is very fragile, must map 1-to-1 with zstd's)
- We actually just need DstSizeTooSmall error which we now have a check for and a test