### PR TITLE
Prevent panic when decompression input slice is empty

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -94,6 +94,9 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 // prevent allocation.  If it is too small, or if nil is passed, a new buffer
 // will be allocated and returned.
 func Decompress(dst, src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return []byte{}, ErrEmptySlice
+	}
 	decompress := func(dst, src []byte) ([]byte, error) {
 
 		cWritten := C.ZSTD_decompress_wrapper(

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -84,8 +84,15 @@ func TestCompressDecompress(t *testing.T) {
 	}
 }
 
-func TestEmptySlice(t *testing.T) {
+func TestEmptySliceCompress(t *testing.T) {
 	_, err := Compress(nil, []byte{})
+	if err != ErrEmptySlice {
+		t.Fatalf("Did not get the correct error: %s", err)
+	}
+}
+
+func TestEmptySliceDecompress(t *testing.T) {
+	_, err := Decompress(nil, []byte{})
 	if err != ErrEmptySlice {
 		t.Fatalf("Did not get the correct error: %s", err)
 	}


### PR DESCRIPTION
This returns an error instead of an `index out of range` panic when the src slice to Decompress() is empty. The function uses `&src[0]` without first confirming the length.