### PR TITLE
Handle short reads and reader failures differently

### DIFF
--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -8,6 +8,7 @@ package zstd
 */
 import "C"
 import (
+	"errors"
 	"fmt"
 	"io"
 	"unsafe"
@@ -222,11 +223,11 @@ func (r *reader) Read(p []byte) (int, error) {
 		// Populate src
 		src := r.compressionBuffer
 		reader := r.underlyingReader
-		n, err := io.ReadFull(reader, src[r.compressionLeft:])
-		if err == io.EOF && r.compressionLeft == 0 {
-			return got, io.EOF
-		} else if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		n, err := TryReadFull(reader, src[r.compressionLeft:])
+		if err != nil && err != ErrShortRead { // Handle underlying reader errors first
 			return 0, fmt.Errorf("failed to read from underlying reader: %s", err)
+		} else if n == 0 && r.compressionLeft == 0 {
+			return got, io.EOF
 		}
 		src = src[:r.compressionLeft+n]
 
@@ -267,3 +268,24 @@ func (r *reader) Read(p []byte) (int, error) {
 	}
 	return got, nil
 }
+
+// TryReadFull reads buffer just as ReadFull does
+// Here we expect that buffer may end and we do not return ErrUnexpectedEOF as ReadAtLeast does.
+// We return ErrShortRead instead to distinguish short reads and failures.
+// We cannot use ReadFull/ReadAtLeast because it masks Reader errors, such as network failures
+// and causes panic instead of error.
+func TryReadFull(r io.Reader, buf []byte) (n int, err error) {
+	for n < len(buf) && err == nil {
+		var nn int
+		nn, err = r.Read(buf[n:])
+		n += nn
+	}
+	if n == len(buf) && err == io.EOF {
+		err = nil // EOF at the end is somewhat expected
+	} else if err == io.EOF {
+		err = ErrShortRead
+	}
+	return
+}
+
+var ErrShortRead = errors.New("short read")

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -171,3 +171,18 @@ func BenchmarkStreamDecompression(b *testing.B) {
 		}
 	}
 }
+
+type breakingReader struct {
+}
+
+func (r *breakingReader) Read(p []byte) (int, error) {
+	return len(p) - 1, io.ErrUnexpectedEOF
+}
+
+func TestUnexpectedEOFHandling(t *testing.T) {
+	r := NewReader(&breakingReader{})
+	_, err := r.Read(make([]byte, 1024))
+	if err == nil {
+		t.Error("Underlying error was handled silently")
+	}
+}


### PR DESCRIPTION
I expect this should fix #36 .
In case of network failures in [WAL-G](https:://github.com/wal-g/wal-g) Reader may return ErrUnexpectedEOF and this error could possibly be mistakenly ignored, leading to panic.