### PR TITLE
[travis] Update CI for 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 os:
   - linux


### PR DESCRIPTION
We want to support the last 2 versions, so removing testing for Go 1.8.
Testing will be for Go 1.9, 1.10, 1.11