### PR TITLE
decompress: allocate decompression context on stack

### DIFF
--- a/zstd_decompress.c
+++ b/zstd_decompress.c
@@ -38,7 +38,7 @@
  * in memory stack (0), or in memory heap (1, requires malloc())
  */
 #ifndef ZSTD_HEAPMODE
-#  define ZSTD_HEAPMODE 1
+#  define ZSTD_HEAPMODE 0
 #endif
 
 /*!
@@ -1161,4 +1161,3 @@ size_t ZSTD_decompressBegin_usingDict(ZSTD_DCtx* dctx, const void* dict, size_t 
 
     return 0;
 }
-


### PR DESCRIPTION
By default `zstd` allocates decompression state on heap. It makes hard to analize Go app memory usage since cgo memory allocations are not visible in memory profiler.
It may potentially lead to "memory leak" if memory allocator doesn't return the allocated memory to the OS or the the memory pool of the Go allocator.
The size of the decompression context is 157848 Bytes which is fine in most of Go applications.

Benchmark doesn't expose any regression (ran on darwin/amd64 OS):

On heap:
```
BenchmarkStreamCompression-4     	      50	  38271109 ns/op	 273.99 MB/s	25378585 B/op	       4 allocs/op
BenchmarkStreamDecompression-4   	     200	   6645842 ns/op	1577.79 MB/s	32654594 B/op	     497 allocs/op
BenchmarkCompression-4           	      50	  24747085 ns/op	 423.72 MB/s	      96 B/op	       4 allocs/op
BenchmarkDecompression-4         	    2000	    865110 ns/op	12120.72 MB/s	      96 B/op	       4 allocs/op
```

On stack:
```
BenchmarkStreamCompression-4     	      50	  38984672 ns/op	 268.97 MB/s	25378585 B/op	       4 allocs/op
BenchmarkStreamDecompression-4   	     200	   6653201 ns/op	1576.05 MB/s	32654592 B/op	     497 allocs/op
BenchmarkCompression-4           	      50	  25819320 ns/op	 406.12 MB/s	      96 B/op	       4 allocs/op
BenchmarkDecompression-4         	    2000	    788747 ns/op	13294.18 MB/s	      96 B/op	       4 allocs/op

```