### PR TITLE
Correctly handle compressing empty slice

### DIFF
--- a/zstd_test.go
+++ b/zstd_test.go
@@ -85,9 +85,17 @@ func TestCompressDecompress(t *testing.T) {
 }
 
 func TestEmptySliceCompress(t *testing.T) {
-	_, err := Compress(nil, []byte{})
-	if err != ErrEmptySlice {
-		t.Fatalf("Did not get the correct error: %s", err)
+	compressed, err := Compress(nil, []byte{})
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	t.Logf("Compressing empty slice gives 0x%x", compressed)
+	decompressed, err := Decompress(nil, compressed)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	if string(decompressed) != "" {
+		t.Fatalf("Expected empty slice as decompressed, got %v instead", decompressed)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/DataDog/zstd/issues/41

The current behavior is on the `Compress` / `Decompress`, when we give an empty slice for compression, the library return an `EmptySlice` error. This makes sense for `Decompress` (since it's not a correct zstd message) but not for `Compress`.

Also this has a different behavior than the streaming version as those works correctly with empty slices

As https://github.com/DataDog/zstd/issues/41 points out, the `zstd` cli correctly returns a slice for empty slice, we should do the same