### PR TITLE
Fix tests for 32 bits systems and provide an env to test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,18 @@ os:
   - linux
   - osx
 
+matrix:
+  include:
+    name: "Go 1.11.x CentOS 32bits"
+    language: go
+    go: 1.11.x
+    os: linux
+    services:
+      - docker
+    script:
+      # Please update Go version in travis_test_32 as needed
+      - "docker run -i -v \"${PWD}:/zstd\" toopher/centos-i386:centos6 /bin/bash -c \"linux32 --32bit i386 /zstd/travis_test_32.sh\""
+
 install:
   - "wget https://github.com/DataDog/zstd/files/2246767/mr.zip"
   - "unzip mr.zip"

--- a/travis_test_32.sh
+++ b/travis_test_32.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Get utilities
+yum -y -q -e 0 install wget tar unzip gcc
+
+# Get Go
+wget -q https://dl.google.com/go/go1.11.1.linux-386.tar.gz
+tar -C /usr/local -xzf go1.11.1.linux-386.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+
+# Get payload
+wget -q https://github.com/DataDog/zstd/files/2246767/mr.zip
+unzip mr.zip
+
+# Build and run tests
+cd zstd
+go build
+PAYLOAD=$(pwd)/mr go test -v
+PAYLOAD=$(pwd)/mr go test -bench .

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -27,7 +27,7 @@ func init() {
 
 // Test our version of compress bound vs C implementation
 func TestCompressBound(t *testing.T) {
-	tests := []int{0, 1, 2, 10, 456, 15468, 1313, 512, 54564654653}
+	tests := []int{0, 1, 2, 10, 456, 15468, 1313, 512, 2147483632}
 	for _, test := range tests {
 		if CompressBound(test) != cCompressBound(test) {
 			t.Fatalf("For %v, results are different: %v (actual) != %v (expected)", test,


### PR DESCRIPTION
Fixes https://github.com/DataDog/zstd/issues/44

We were basically using a constant in the test that was overflowing int 32 bits.
This PR fixes it (uses `2147483632` instead of `54564654653`)

It also adds a build matrix to test building and testing on a 32 bits centos