### PR TITLE
prevent a out of range panic in Decompress

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -115,7 +115,7 @@ func Decompress(dst, src []byte) ([]byte, error) {
 		return dst[:written], nil
 	}
 
-	if dst == nil {
+	if len(dst) == 0 {
 		// Attempt to use zStd to determine decompressed size (may result in error or 0)
 		size := int(C.size_t(C.ZSTD_getDecompressedSize(unsafe.Pointer(&src[0]), C.size_t(len(src)))))
 

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -106,6 +106,24 @@ func TestEmptySliceDecompress(t *testing.T) {
 	}
 }
 
+func TestDecompressZeroLengthBuf(t *testing.T) {
+	input := []byte("Hello World!")
+	out, err := Compress(nil, input)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+
+	buf := make([]byte, 0)
+	decompressed, err := Decompress(buf, out)
+	if err != nil {
+		t.Fatalf("Error while decompressing: %v", err)
+	}
+
+	if res, exp := string(input), string(decompressed); res != exp {
+		t.Fatalf("expected %s but decompressed to %s", exp, res)
+	}
+}
+
 func TestTooSmall(t *testing.T) {
 	var long bytes.Buffer
 	for i := 0; i < 10000; i++ {


### PR DESCRIPTION
If dst is not nil but has length 0 the call to decompress() will panic.

Example code ((contrived and useless but shows the point):

    package main
    
    import (
    	"log"
    
    	"github.com/DataDog/zstd"
    )
    
    func main() {
    	buf := make([]byte, 0)    
    	value := []byte("foobar")
    
    	_, err := zstd.Decompress(buf, value)
    	if err != nil {
    		log.Fatal(err)
    	}
    }

I get this panic:

    $ go run main.go
    panic: runtime error: index out of range
    
    goroutine 1 [running]:
    github.com/DataDog/zstd.Decompress.func1(0x61e660, 0x0, 0x0, 0xc00009a010, 0x6, 0x8, 0x2, 0x0, 0xc00009a010, 0x8, ...)
            /home/vincent/dev/go/src/github.com/DataDog/zstd/zstd.go:105 +0xfa
    github.com/DataDog/zstd.Decompress(0x61e660, 0x0, 0x0, 0xc00009a010, 0x6, 0x8, 0x0, 0x0, 0x0, 0x0, ...)
            /home/vincent/dev/go/src/github.com/DataDog/zstd/zstd.go:133 +0x11d
    main.main()
            /home/vincent/tmp/zstd/main.go:14 +0xa9

With the fix:

    $ go run main.go
    2018/12/28 19:05:54 Unknown frame descriptor
