### PR TITLE
backport #42 to 0.5.x (Correctly handle compressing empty slice), handle decompressing empty byte slice

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -107,9 +107,6 @@ func Compress(dst, src []byte) ([]byte, error) {
 
 // CompressLevel is the same as Compress but you can pass a compression level
 func CompressLevel(dst, src []byte, level int) ([]byte, error) {
-	if len(src) == 0 {
-		return []byte{}, ErrEmptySlice
-	}
 	bound := CompressBound(len(src))
 	if cap(dst) >= bound {
 		dst = dst[0:bound] // Reuse dst buffer
@@ -117,10 +114,15 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		dst = make([]byte, bound)
 	}
 
+	srcPtr := unsafe.Pointer(nil) // Do not point anywhere, if src is empty
+	if len(src) > 0 {
+		srcPtr = unsafe.Pointer(&src[0])
+	}
+
 	cWritten := C.ZSTD_compress(
 		unsafe.Pointer(&dst[0]),
 		C.size_t(len(dst)),
-		unsafe.Pointer(&src[0]),
+		srcPtr,
 		C.size_t(len(src)),
 		C.int(level))
 
@@ -139,6 +141,9 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 // 3 times before falling back to the slower stream API (ie. if the compression
 // ratio is 32).
 func Decompress(dst, src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return []byte{}, ErrEmptySlice
+	}
 	decompress := func(dst, src []byte) ([]byte, error) {
 
 		cWritten := C.ZSTD_decompress(

--- a/zstd.go
+++ b/zstd.go
@@ -114,17 +114,22 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		dst = make([]byte, bound)
 	}
 
-	srcPtr := unsafe.Pointer(nil) // Do not point anywhere, if src is empty
+	var cWritten C.size_t
 	if len(src) > 0 {
-		srcPtr = unsafe.Pointer(&src[0])
+		cWritten = C.ZSTD_compress(
+			unsafe.Pointer(&dst[0]),
+			C.size_t(len(dst)),
+			unsafe.Pointer(&src[0]),
+			C.size_t(len(src)),
+			C.int(level))
+	} else {
+		cWritten = C.ZSTD_compress(
+			unsafe.Pointer(&dst[0]),
+			C.size_t(len(dst)),
+			unsafe.Pointer(nil),
+			C.size_t(len(src)),
+			C.int(level))
 	}
-
-	cWritten := C.ZSTD_compress(
-		unsafe.Pointer(&dst[0]),
-		C.size_t(len(dst)),
-		srcPtr,
-		C.size_t(len(src)),
-		C.int(level))
 
 	written := int(cWritten)
 	// Check if the return is an Error code

--- a/zstd.go
+++ b/zstd.go
@@ -123,6 +123,10 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 			C.size_t(len(src)),
 			C.int(level))
 	} else {
+		// Special case for when src is empty.
+		// If you refactor this, careful not to store unsafe.Pointer(nil) in a
+		// variable or else you'll hit
+		// https://github.com/golang/go/issues/28606
 		cWritten = C.ZSTD_compress(
 			unsafe.Pointer(&dst[0]),
 			C.size_t(len(dst)),

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -3,6 +3,7 @@ package zstd
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"testing"
 )
 
@@ -123,6 +124,27 @@ func TestStreamRealPayload(t *testing.T) {
 		t.Skip(ErrNoPayloadEnv)
 	}
 	testCompressionDecompression(t, nil, raw)
+}
+
+func TestStreamEmptyPayload(t *testing.T) {
+	w := bytes.NewBuffer(nil)
+	writer := NewWriter(w)
+	_, err := writer.Write(nil)
+	failOnError(t, "failed to write empty slice", err)
+	err = writer.Close()
+	failOnError(t, "failed to close", err)
+	compressed := w.Bytes()
+	t.Logf("compressed buffer: 0x%x", compressed)
+	// Now recheck that if we decompress, we get empty slice
+	r := bytes.NewBuffer(compressed)
+	reader := NewReader(r)
+	decompressed, err := ioutil.ReadAll(reader)
+	failOnError(t, "failed to read", err)
+	err = reader.Close()
+	failOnError(t, "failed to close", err)
+	if string(decompressed) != "" {
+		t.Fatalf("Expected empty slice as decompressed, got %v instead", decompressed)
+	}
 }
 
 func BenchmarkStreamCompression(b *testing.B) {

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -84,8 +84,23 @@ func TestCompressDecompress(t *testing.T) {
 	}
 }
 
-func TestEmptySlice(t *testing.T) {
-	_, err := Compress(nil, []byte{})
+func TestEmptySliceCompress(t *testing.T) {
+	compressed, err := Compress(nil, []byte{})
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	t.Logf("Compressing empty slice gives 0x%x", compressed)
+	decompressed, err := Decompress(nil, compressed)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	if string(decompressed) != "" {
+		t.Fatalf("Expected empty slice as decompressed, got %v instead", decompressed)
+	}
+}
+
+func TestEmptySliceDecompress(t *testing.T) {
+	_, err := Decompress(nil, []byte{})
 	if err != ErrEmptySlice {
 		t.Fatalf("Did not get the correct error: %s", err)
 	}


### PR DESCRIPTION
Backports https://github.com/DataDog/zstd/pull/42 to `0.5.x`. Also makes decompressing an empty byte slice consistent with the `1.x` version (by retuning `ErrEmptySlice`)