### PR TITLE
[zstd] Properly keep alive src

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"io/ioutil"
+	"runtime"
 	"unsafe"
 )
 
@@ -84,6 +85,7 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		C.size_t(len(src)),
 		C.int(level))
 
+	runtime.KeepAlive(src)
 	written := int(cWritten)
 	// Check if the return is an Error code
 	if err := getError(written); err != nil {
@@ -107,6 +109,7 @@ func Decompress(dst, src []byte) ([]byte, error) {
 			C.uintptr_t(uintptr(unsafe.Pointer(&src[0]))),
 			C.size_t(len(src)))
 
+		runtime.KeepAlive(src)
 		written := int(cWritten)
 		// Check error
 		if err := getError(written); err != nil {

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"unsafe"
 )
 
@@ -243,6 +244,8 @@ func (r *reader) Read(p []byte) (int, error) {
 			unsafe.Pointer(&src[0]),
 			&cSrcSize))
 
+		// Keep src here eventhough, we reuse later, the code might be deleted at some point
+		runtime.KeepAlive(src)
 		if err = getError(retCode); err != nil {
 			return 0, fmt.Errorf("failed to decompress: %s", err)
 		}


### PR DESCRIPTION
In Go 1.12, inlining got more aggressive so here it can now detect that src is not used and GC earlier. We need to force tell Go that we are still using the variable.

See https://github.com/DataDog/zstd/pull/54