### PR TITLE
[travis] Bump to Xenial and test on Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ dist: xenial
 language: go
 
 go:
-  - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
 
 os:
   - linux


### PR DESCRIPTION
According to golang/go#31293
there seems to be an incompatibility  with the newest gcc and cgo.
Current fix is to bump to xenial but there should be CL incoming as well https://golang.org/cl/171121

Also add testing on Go 1.12 and remove Go 1.9 (only latest 3 releases)