### PR TITLE
[zstd_stream] Now use ZSTD_compressStream2 C API

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,40 @@
+package zstd
+
+import (
+	"io"
+	"math/rand"
+	"time"
+)
+
+// randbytes creates a stream of non-crypto quality random bytes
+type randbytes struct {
+	rand.Source
+}
+
+// NewRandBytes creates a new random reader with a time source.
+func NewRandBytes() io.Reader {
+	return NewRandBytesFrom(rand.NewSource(time.Now().UnixNano()))
+}
+
+// NewRandBytesFrom creates a new reader from your own rand.Source
+func NewRandBytesFrom(src rand.Source) io.Reader {
+	return &randbytes{src}
+}
+
+// Read satisfies io.Reader
+func (r *randbytes) Read(p []byte) (n int, err error) {
+	todo := len(p)
+	offset := 0
+	for {
+		val := int64(r.Int63())
+		for i := 0; i < 8; i++ {
+			p[offset] = byte(val)
+			todo--
+			if todo == 0 {
+				return len(p), nil
+			}
+			offset++
+			val >>= 8
+		}
+	}
+}


### PR DESCRIPTION
Based on comments from #22 & #39

This PR moves the stream compression C calls from the deprecated `ZSTD_compressBegin` / `ZSTD_compressContinue` to the current stable `ZSTD_compressStream2 ` API

It allows piggy-back on https://github.com/DataDog/zstd/pull/31 to do the same for the streaming interface

See https://github.com/facebook/zstd/blob/5120883a9c29a7966bbd2144df04f6976f4c7acc/lib/zstd.h#L576 for streaming best practices

(I'll do the Decompression API change in a separate PR to reduce the size of the PR and also technically the 2 changes can be made independently) 