### PR TITLE
[zstd_stream] Now use ZSTD_decompressStream C API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ There are two main APIs:
 The compress/decompress APIs mirror that of lz4, while the streaming API was
 designed to be a drop-in replacement for zlib.
 
-## Current status
-
-There is currently a potential issue with the streaming `Writer` interface. See https://github.com/DataDog/zstd/issues/22 for more details.
-If you intend to use the streaming interface instead of `Compress` method, it is currently recommended to use [release 1.3.0](https://github.com/DataDog/zstd/releases/tag/v1.3.0) or earlier.
-If you are able to contribute or reproduce the issue, please let us know!
-
 ### Simple `Compress/Decompress`
 
 
@@ -79,8 +73,6 @@ NewReader(r io.Reader) io.ReadCloser
 NewReaderDict(r io.Reader, dict []byte) io.ReadCloser
 ```
 
-See section above `Current Status`
-
 ### Benchmarks (benchmarked with v0.5.0)
 
 The author of Zstd also wrote lz4. Zstd is intended to occupy a speed/ratio
@@ -124,3 +116,9 @@ Testing with size: 45951... czlib: 201.62 MB/s, zstd: 1951.57 MB/s
 ```
 
 zstd starts to shine with payloads > 1KB
+
+### Stability - Current state: STABLE
+
+The C library seems to be pretty stable and according to the author has been tested and fuzzed.
+
+For the Go wrapper, the test cover most usual cases and we have succesfully tested it on all staging and prod data.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,5 +1,10 @@
 package zstd
 
+/*
+From https://github.com/dustin/randbo
+All credits for the code below goes there :) (There wasn't a license so I'm distributing as is)
+*/
+
 import (
 	"io"
 	"math/rand"

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -2,10 +2,8 @@ package zstd
 
 /*
 #define ZSTD_STATIC_LINKING_ONLY
-#define ZBUFF_DISABLE_DEPRECATE_WARNINGS
 #include "stdint.h"  // for uintptr_t
 #include "zstd.h"
-#include "zbuff.h"
 
 typedef struct compressStream2_result_s {
 	size_t return_code;


### PR DESCRIPTION
Follow up of https://github.com/DataDog/zstd/pull/79 but for the decompression side.

This:
- [x] add a test only for stream decompression
- [x] Potential pre-emptive fix for https://github.com/DataDog/zstd/pull/69 if there is any reuse of a reader after `Close()` has been called (see https://github.com/DataDog/zstd/commit/0932c165cc228f581afc5be24a264a433e275d3b)
- [x] Move Decompression API from the (now deprecated) ZBUFF_decompressInit / ZBUFF_decompressContinue API to ZSTD_decompressStream
- [x] Add some C passthrough methods to not have to allocated pointers
- [x] Switch from ZBUFF private methods to ZSTD methods and structs
- [x] Revert https://github.com/DataDog/zstd/pull/77 now that we use the recommended APIs

This PR is against https://github.com/DataDog/zstd/pull/79 branch not `1.x` to be able to merge both at the same time (and have a smaller diff)