### PR TITLE
Added Ctx compress/decompress

### DIFF
--- a/zstd_ctx.go
+++ b/zstd_ctx.go
@@ -1,0 +1,159 @@
+package zstd
+
+/*
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+#include "stdint.h"  // for uintptr_t
+
+// The following *_wrapper function are used for removing superflouos
+// memory allocations when calling the wrapped functions from Go code.
+// See https://github.com/golang/go/issues/24450 for details.
+
+static size_t ZSTD_compressCCtx_wrapper(ZSTD_CCtx* cctx, uintptr_t dst, size_t maxDstSize, const uintptr_t src, size_t srcSize, int compressionLevel) {
+	return ZSTD_compressCCtx(cctx, (void*)dst, maxDstSize, (const void*)src, srcSize, compressionLevel);
+}
+
+static size_t ZSTD_decompressDCtx_wrapper(ZSTD_DCtx* dctx, uintptr_t dst, size_t maxDstSize, uintptr_t src, size_t srcSize) {
+	return ZSTD_decompressDCtx(dctx, (void*)dst, maxDstSize, (const void *)src, srcSize);
+}
+
+*/
+import "C"
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"runtime"
+	"unsafe"
+)
+
+type Ctx interface {
+	// Compress src into dst.  If you have a buffer to use, you can pass it to
+	// prevent allocation.  If it is too small, or if nil is passed, a new buffer
+	// will be allocated and returned.
+	Compress(dst, src []byte) ([]byte, error)
+
+	// CompressLevel is the same as Compress but you can pass a compression level
+	CompressLevel(dst, src []byte, level int) ([]byte, error)
+
+	// Decompress src into dst.  If you have a buffer to use, you can pass it to
+	// prevent allocation.  If it is too small, or if nil is passed, a new buffer
+	// will be allocated and returned.
+	Decompress(dst, src []byte) ([]byte, error)
+
+	io.Closer
+}
+
+type ctx struct {
+	cctx *C.ZSTD_CCtx
+	dctx *C.ZSTD_DCtx
+}
+
+// Create a new ZStd Context.
+//  When compressing/decompressing many times, it is recommended to allocate a
+//  context just once, and re-use it for each successive compression operation.
+//  This will make workload friendlier for system's memory.
+//  Note : re-using context is just a speed / resource optimization.
+//         It doesn't change the compression ratio, which remains identical.
+//  Note 2 : In multi-threaded environments,
+//         use one different context per thread for parallel execution.
+//
+func NewCtx() Ctx {
+	return &ctx{
+		cctx: C.ZSTD_createCCtx(),
+		dctx: C.ZSTD_createDCtx(),
+	}
+}
+
+func (c *ctx) Compress(dst, src []byte) ([]byte, error) {
+	return c.CompressLevel(dst, src, DefaultCompression)
+}
+
+func (c *ctx) CompressLevel(dst, src []byte, level int) ([]byte, error) {
+	bound := CompressBound(len(src))
+	if cap(dst) >= bound {
+		dst = dst[0:bound] // Reuse dst buffer
+	} else {
+		dst = make([]byte, bound)
+	}
+
+	srcPtr := C.uintptr_t(uintptr(0)) // Do not point anywhere, if src is empty
+	if len(src) > 0 {
+		srcPtr = C.uintptr_t(uintptr(unsafe.Pointer(&src[0])))
+	}
+
+	cWritten := C.ZSTD_compressCCtx_wrapper(
+		c.cctx,
+		C.uintptr_t(uintptr(unsafe.Pointer(&dst[0]))),
+		C.size_t(len(dst)),
+		srcPtr,
+		C.size_t(len(src)),
+		C.int(level))
+
+	runtime.KeepAlive(src)
+	written := int(cWritten)
+	// Check if the return is an Error code
+	if err := getError(written); err != nil {
+		return nil, err
+	}
+	return dst[:written], nil
+}
+
+
+func (c *ctx) Decompress(dst, src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return []byte{}, ErrEmptySlice
+	}
+	decompress := func(dst, src []byte) ([]byte, error) {
+
+		cWritten := C.ZSTD_decompressDCtx_wrapper(
+			c.dctx,
+			C.uintptr_t(uintptr(unsafe.Pointer(&dst[0]))),
+			C.size_t(len(dst)),
+			C.uintptr_t(uintptr(unsafe.Pointer(&src[0]))),
+			C.size_t(len(src)))
+
+		runtime.KeepAlive(src)
+		written := int(cWritten)
+		// Check error
+		if err := getError(written); err != nil {
+			return nil, err
+		}
+		return dst[:written], nil
+	}
+
+	if len(dst) == 0 {
+		// Attempt to use zStd to determine decompressed size (may result in error or 0)
+		size := int(C.size_t(C.ZSTD_getDecompressedSize(unsafe.Pointer(&src[0]), C.size_t(len(src)))))
+
+		if err := getError(size); err != nil {
+			return nil, err
+		}
+
+		if size > 0 {
+			dst = make([]byte, size)
+		} else {
+			dst = make([]byte, len(src)*3) // starting guess
+		}
+	}
+	for i := 0; i < 3; i++ { // 3 tries to allocate a bigger buffer
+		result, err := decompress(dst, src)
+		if !IsDstSizeTooSmallError(err) {
+			return result, err
+		}
+		dst = make([]byte, len(dst)*2) // Grow buffer by 2
+	}
+
+	// We failed getting a dst buffer of correct size, use stream API
+	r := NewReader(bytes.NewReader(src))
+	defer r.Close()
+	return ioutil.ReadAll(r)
+}
+
+func (c *ctx) Close() error {
+	if err := getError(int(C.ZSTD_freeCCtx(c.cctx))); err != nil {
+		return err
+	}
+
+	return getError(int(C.ZSTD_freeDCtx(c.dctx)))
+}

--- a/zstd_ctx.go
+++ b/zstd_ctx.go
@@ -5,7 +5,7 @@ package zstd
 #include "zstd.h"
 #include "stdint.h"  // for uintptr_t
 
-// The following *_wrapper function are used for removing superflouos
+// The following *_wrapper function are used for removing superfluous
 // memory allocations when calling the wrapped functions from Go code.
 // See https://github.com/golang/go/issues/24450 for details.
 

--- a/zstd_ctx_test.go
+++ b/zstd_ctx_test.go
@@ -8,7 +8,6 @@ import (
 // Test compression
 func TestCtxCompressDecompress(t *testing.T) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	input := []byte("Hello World!")
 	out, err := ctx.Compress(nil, input)
@@ -42,7 +41,6 @@ func TestCtxCompressDecompress(t *testing.T) {
 
 func TestCtxEmptySliceCompress(t *testing.T) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	compressed, err := ctx.Compress(nil, []byte{})
 	if err != nil {
@@ -60,7 +58,6 @@ func TestCtxEmptySliceCompress(t *testing.T) {
 
 func TestCtxEmptySliceDecompress(t *testing.T) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	_, err := ctx.Decompress(nil, []byte{})
 	if err != ErrEmptySlice {
@@ -70,7 +67,6 @@ func TestCtxEmptySliceDecompress(t *testing.T) {
 
 func TestCtxDecompressZeroLengthBuf(t *testing.T) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	input := []byte("Hello World!")
 	out, err := ctx.Compress(nil, input)
@@ -91,7 +87,6 @@ func TestCtxDecompressZeroLengthBuf(t *testing.T) {
 
 func TestCtxTooSmall(t *testing.T) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	var long bytes.Buffer
 	for i := 0; i < 10000; i++ {
@@ -115,7 +110,6 @@ func TestCtxTooSmall(t *testing.T) {
 
 func TestCtxRealPayload(t *testing.T) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	if raw == nil {
 		t.Skip(ErrNoPayloadEnv)
@@ -135,7 +129,6 @@ func TestCtxRealPayload(t *testing.T) {
 
 func BenchmarkCtxCompression(b *testing.B) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	if raw == nil {
 		b.Fatal(ErrNoPayloadEnv)
@@ -153,7 +146,6 @@ func BenchmarkCtxCompression(b *testing.B) {
 
 func BenchmarkCtxDecompression(b *testing.B) {
 	ctx := NewCtx()
-	defer ctx.Close()
 
 	if raw == nil {
 		b.Fatal(ErrNoPayloadEnv)

--- a/zstd_ctx_test.go
+++ b/zstd_ctx_test.go
@@ -1,0 +1,180 @@
+package zstd
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Test compression
+func TestCtxCompressDecompress(t *testing.T) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	input := []byte("Hello World!")
+	out, err := ctx.Compress(nil, input)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	out2 := make([]byte, 1000)
+	out2, err = ctx.Compress(out2, input)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	t.Logf("Compressed: %v", out)
+
+	rein, err := ctx.Decompress(nil, out)
+	if err != nil {
+		t.Fatalf("Error while decompressing: %v", err)
+	}
+	rein2 := make([]byte, 10)
+	rein2, err = ctx.Decompress(rein2, out2)
+	if err != nil {
+		t.Fatalf("Error while decompressing: %v", err)
+	}
+
+	if string(input) != string(rein) {
+		t.Fatalf("Cannot compress and decompress: %s != %s", input, rein)
+	}
+	if string(input) != string(rein2) {
+		t.Fatalf("Cannot compress and decompress: %s != %s", input, rein)
+	}
+}
+
+func TestCtxEmptySliceCompress(t *testing.T) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	compressed, err := ctx.Compress(nil, []byte{})
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	t.Logf("Compressing empty slice gives 0x%x", compressed)
+	decompressed, err := ctx.Decompress(nil, compressed)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	if string(decompressed) != "" {
+		t.Fatalf("Expected empty slice as decompressed, got %v instead", decompressed)
+	}
+}
+
+func TestCtxEmptySliceDecompress(t *testing.T) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	_, err := ctx.Decompress(nil, []byte{})
+	if err != ErrEmptySlice {
+		t.Fatalf("Did not get the correct error: %s", err)
+	}
+}
+
+func TestCtxDecompressZeroLengthBuf(t *testing.T) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	input := []byte("Hello World!")
+	out, err := ctx.Compress(nil, input)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+
+	buf := make([]byte, 0)
+	decompressed, err := ctx.Decompress(buf, out)
+	if err != nil {
+		t.Fatalf("Error while decompressing: %v", err)
+	}
+
+	if res, exp := string(input), string(decompressed); res != exp {
+		t.Fatalf("expected %s but decompressed to %s", exp, res)
+	}
+}
+
+func TestCtxTooSmall(t *testing.T) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	var long bytes.Buffer
+	for i := 0; i < 10000; i++ {
+		long.Write([]byte("Hellow World!"))
+	}
+	input := long.Bytes()
+	out, err := ctx.Compress(nil, input)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	rein := make([]byte, 1)
+	// This should switch to the decompression stream to handle too small dst
+	rein, err = ctx.Decompress(rein, out)
+	if err != nil {
+		t.Fatalf("Failed decompressing: %s", err)
+	}
+	if string(input) != string(rein) {
+		t.Fatalf("Cannot compress and decompress: %s != %s", input, rein)
+	}
+}
+
+func TestCtxRealPayload(t *testing.T) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	if raw == nil {
+		t.Skip(ErrNoPayloadEnv)
+	}
+	dst, err := ctx.Compress(nil, raw)
+	if err != nil {
+		t.Fatalf("Failed to compress: %s", err)
+	}
+	rein, err := ctx.Decompress(nil, dst)
+	if err != nil {
+		t.Fatalf("Failed to decompress: %s", err)
+	}
+	if string(raw) != string(rein) {
+		t.Fatalf("compressed/decompressed payloads are not the same (lengths: %v & %v)", len(raw), len(rein))
+	}
+}
+
+func BenchmarkCtxCompression(b *testing.B) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	if raw == nil {
+		b.Fatal(ErrNoPayloadEnv)
+	}
+	dst := make([]byte, CompressBound(len(raw)))
+	b.SetBytes(int64(len(raw)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ctx.Compress(dst, raw)
+		if err != nil {
+			b.Fatalf("Failed compressing: %s", err)
+		}
+	}
+}
+
+func BenchmarkCtxDecompression(b *testing.B) {
+	ctx := NewCtx()
+	defer ctx.Close()
+
+	if raw == nil {
+		b.Fatal(ErrNoPayloadEnv)
+	}
+	src := make([]byte, len(raw))
+	dst, err := ctx.Compress(nil, raw)
+	if err != nil {
+		b.Fatalf("Failed compressing: %s", err)
+	}
+	b.Logf("Reduced from %v to %v", len(raw), len(dst))
+	b.SetBytes(int64(len(raw)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src2, err := ctx.Decompress(src, dst)
+		if err != nil {
+			b.Fatalf("Failed decompressing: %s", err)
+		}
+		b.StopTimer()
+		if !bytes.Equal(raw, src2) {
+			b.Fatalf("Results are not the same: %v != %v", len(raw), len(src2))
+		}
+		b.StartTimer()
+	}
+}


### PR DESCRIPTION
### Motivation
According to https://facebook.github.io/zstd/zstd_manual.html#Chapter4 when doing repeated compression/decompression operations, it's recommended to use a context object for internal state to be preserved.

```
  When compressing many times,
  it is recommended to allocate a context just once,
  and re-use it for each successive compression operation.
  This will make workload friendlier for system's memory.
  Note : re-using context is just a speed / resource optimization.
         It doesn't change the compression ratio, which remains identical.
  Note 2 : In multi-threaded environments,
         use one different context per thread for parallel execution.
```

While this could be done similarly through the stream API, it doesn't come natural when compressing a `[]byte` and it doesn't provide a way to provide a `dst` buffer for the result.

### Modifications

In order to expose the `ZSTD_compressCCtx()` and `ZSTD_decompressDCtx()`, adding a `Ctx` interface: 

```go
type Ctx interface {
	// Compress src into dst.  If you have a buffer to use, you can pass it to
	// prevent allocation.  If it is too small, or if nil is passed, a new buffer
	// will be allocated and returned.
	Compress(dst, src []byte) ([]byte, error)

	// CompressLevel is the same as Compress but you can pass a compression level
	CompressLevel(dst, src []byte, level int) ([]byte, error)

	// Decompress src into dst.  If you have a buffer to use, you can pass it to
	// prevent allocation.  If it is too small, or if nil is passed, a new buffer
	// will be allocated and returned.
	Decompress(dst, src []byte) ([]byte, error)

	io.Closer
}
```

Example: 

```go
ctx := zstd.NewCtx()

out1, err := ctx.Compress(nil, input1)
out2, err := ctx.Compress(nil, input2)
// ...

ctx.Close()
```

### Microbenchmark

```
BenchmarkCtxCompression
BenchmarkCtxCompression-16         	     207	   5189899 ns/op	 345.87 MB/s
BenchmarkCtxDecompression
    BenchmarkCtxDecompression: zstd_ctx_test.go:166: Reduced from 1795030 to 119090
    BenchmarkCtxDecompression: zstd_ctx_test.go:166: Reduced from 1795030 to 119090
    BenchmarkCtxDecompression: zstd_ctx_test.go:166: Reduced from 1795030 to 119090
BenchmarkCtxDecompression-16       	    1548	    679185 ns/op	2642.92 MB/s
BenchmarkStreamCompression
BenchmarkStreamCompression-16      	    5766	    230298 ns/op	7794.38 MB/s
BenchmarkStreamDecompression
BenchmarkStreamDecompression-16    	    1048	   1578035 ns/op	1137.51 MB/s
BenchmarkCompression
BenchmarkCompression-16            	     150	   7384646 ns/op	 243.08 MB/s
BenchmarkDecompression
    BenchmarkDecompression: zstd_test.go:189: Reduced from 1795030 to 119090
    BenchmarkDecompression: zstd_test.go:189: Reduced from 1795030 to 119090
    BenchmarkDecompression: zstd_test.go:189: Reduced from 1795030 to 119090
BenchmarkDecompression-16          	    1357	    783583 ns/op	2290.80 MB/s
```

The benchmark shows that reusing the context improves the overall performance:
 * Compression : 243 MB/s --> 345 MB/s
 * Decompression: 2290 MB/s --> 2642 MB/s

