### PR TITLE
Pass pointers to C as unsafe.Pointer, not uintptr (memory corruption)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,16 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
+  "golang-efence":
+    resource_class: xlarge
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - checkout
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build'
+      - run: 'PAYLOAD=`pwd`/mr GODEBUG=efence=1 go test -v'
   "golang-i386":
     docker:
       - image: 32bit/ubuntu:16.04
@@ -45,4 +55,5 @@ workflows:
       - "golang-1.14"
       - "golang-1.15"
       - "golang-latest"
+      - "golang-efence"
       - "golang-i386"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr GODEBUG=efence=1 go test -v'
   "golang-i386":
-    resource_class: xlarge
     docker:
       - image: 32bit/ubuntu:16.04
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr GODEBUG=efence=1 go test -v'
   "golang-i386":
-    resource_class: large
+    resource_class: xlarge
     docker:
       - image: 32bit/ubuntu:16.04
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr GODEBUG=efence=1 go test -v'
   "golang-i386":
+    resource_class: large
     docker:
       - image: 32bit/ubuntu:16.04
     steps:

--- a/travis_test_32.sh
+++ b/travis_test_32.sh
@@ -15,5 +15,5 @@ unzip mr.zip
 
 # Build and run tests
 go build
-PAYLOAD=$(pwd)/mr go test -v
-PAYLOAD=$(pwd)/mr go test -bench .
+DISABLE_BIG_TESTS=1 PAYLOAD=$(pwd)/mr go test -v
+DISABLE_BIG_TESTS=1 PAYLOAD=$(pwd)/mr go test -bench .

--- a/zstd_ctx.go
+++ b/zstd_ctx.go
@@ -3,20 +3,6 @@ package zstd
 /*
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
-#include "stdint.h"  // for uintptr_t
-
-// The following *_wrapper function are used for removing superfluous
-// memory allocations when calling the wrapped functions from Go code.
-// See https://github.com/golang/go/issues/24450 for details.
-
-static size_t ZSTD_compressCCtx_wrapper(ZSTD_CCtx* cctx, uintptr_t dst, size_t maxDstSize, const uintptr_t src, size_t srcSize, int compressionLevel) {
-	return ZSTD_compressCCtx(cctx, (void*)dst, maxDstSize, (const void*)src, srcSize, compressionLevel);
-}
-
-static size_t ZSTD_decompressDCtx_wrapper(ZSTD_DCtx* dctx, uintptr_t dst, size_t maxDstSize, uintptr_t src, size_t srcSize) {
-	return ZSTD_decompressDCtx(dctx, (void*)dst, maxDstSize, (const void *)src, srcSize);
-}
-
 */
 import "C"
 import (
@@ -77,20 +63,21 @@ func (c *ctx) CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		dst = make([]byte, bound)
 	}
 
-	srcPtr := C.uintptr_t(uintptr(0)) // Do not point anywhere, if src is empty
+	var srcPtr *byte // Do not point anywhere, if src is empty
 	if len(src) > 0 {
-		srcPtr = C.uintptr_t(uintptr(unsafe.Pointer(&src[0])))
+		srcPtr = &src[0]
 	}
 
-	cWritten := C.ZSTD_compressCCtx_wrapper(
+	// This does not use the dangerous uintptr trick because NewCtx returns a Ctx interface,
+	// which means that Go must assume all arguments escape to the heap.
+	cWritten := C.ZSTD_compressCCtx(
 		c.cctx,
-		C.uintptr_t(uintptr(unsafe.Pointer(&dst[0]))),
+		unsafe.Pointer(&dst[0]),
 		C.size_t(len(dst)),
-		srcPtr,
+		unsafe.Pointer(srcPtr),
 		C.size_t(len(src)),
 		C.int(level))
 
-	runtime.KeepAlive(src)
 	written := int(cWritten)
 	// Check if the return is an Error code
 	if err := getError(written); err != nil {
@@ -99,21 +86,19 @@ func (c *ctx) CompressLevel(dst, src []byte, level int) ([]byte, error) {
 	return dst[:written], nil
 }
 
-
 func (c *ctx) Decompress(dst, src []byte) ([]byte, error) {
 	if len(src) == 0 {
 		return []byte{}, ErrEmptySlice
 	}
 	decompress := func(dst, src []byte) ([]byte, error) {
 
-		cWritten := C.ZSTD_decompressDCtx_wrapper(
+		cWritten := C.ZSTD_decompressDCtx(
 			c.dctx,
-			C.uintptr_t(uintptr(unsafe.Pointer(&dst[0]))),
+			unsafe.Pointer(&dst[0]),
 			C.size_t(len(dst)),
-			C.uintptr_t(uintptr(unsafe.Pointer(&src[0]))),
+			unsafe.Pointer(&src[0]),
 			C.size_t(len(src)))
 
-		runtime.KeepAlive(src)
 		written := int(cWritten)
 		// Check error
 		if err := getError(written); err != nil {

--- a/zstd_ctx.go
+++ b/zstd_ctx.go
@@ -68,8 +68,6 @@ func (c *ctx) CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		srcPtr = &src[0]
 	}
 
-	// This does not use the dangerous uintptr trick because NewCtx returns a Ctx interface,
-	// which means that Go must assume all arguments escape to the heap.
 	cWritten := C.ZSTD_compressCCtx(
 		c.cctx,
 		unsafe.Pointer(&dst[0]),

--- a/zstd_ctx_test.go
+++ b/zstd_ctx_test.go
@@ -39,6 +39,32 @@ func TestCtxCompressDecompress(t *testing.T) {
 	}
 }
 
+func TestCtxCompressLevel(t *testing.T) {
+	inputs := [][]byte{
+		nil, {}, {0}, []byte("Hello World!"),
+	}
+
+	cctx := NewCtx()
+	for _, input := range inputs {
+		for level := BestSpeed; level <= BestCompression; level++ {
+			out, err := cctx.CompressLevel(nil, input, level)
+			if err != nil {
+				t.Errorf("input=%#v level=%d CompressLevel failed err=%s", string(input), level, err.Error())
+				continue
+			}
+
+			orig, err := Decompress(nil, out)
+			if err != nil {
+				t.Errorf("input=%#v level=%d Decompress failed err=%s", string(input), level, err.Error())
+				continue
+			}
+			if !bytes.Equal(orig, input) {
+				t.Errorf("input=%#v level=%d orig does not match: %#v", string(input), level, string(orig))
+			}
+		}
+	}
+}
+
 func TestCtxEmptySliceCompress(t *testing.T) {
 	ctx := NewCtx()
 

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -2,7 +2,6 @@ package zstd
 
 /*
 #define ZSTD_STATIC_LINKING_ONLY
-#include "stdint.h"  // for uintptr_t
 #include "zstd.h"
 
 typedef struct compressStream2_result_s {
@@ -11,9 +10,10 @@ typedef struct compressStream2_result_s {
 	size_t bytes_written;
 } compressStream2_result;
 
-static void ZSTD_compressStream2_wrapper(compressStream2_result* result, ZSTD_CCtx* ctx, uintptr_t dst, size_t maxDstSize, const uintptr_t src, size_t srcSize) {
-	ZSTD_outBuffer outBuffer = { (void*)dst, maxDstSize, 0 };
-	ZSTD_inBuffer inBuffer = { (void*)src, srcSize, 0 };
+static void ZSTD_compressStream2_wrapper(compressStream2_result* result, ZSTD_CCtx* ctx,
+		void* dst, size_t maxDstSize, const void* src, size_t srcSize) {
+	ZSTD_outBuffer outBuffer = { dst, maxDstSize, 0 };
+	ZSTD_inBuffer inBuffer = { src, srcSize, 0 };
 	size_t retCode = ZSTD_compressStream2(ctx, &outBuffer, &inBuffer, ZSTD_e_continue);
 
 	result->return_code = retCode;
@@ -21,9 +21,10 @@ static void ZSTD_compressStream2_wrapper(compressStream2_result* result, ZSTD_CC
 	result->bytes_written = outBuffer.pos;
 }
 
-static void ZSTD_compressStream2_flush(compressStream2_result* result, ZSTD_CCtx* ctx, uintptr_t dst, size_t maxDstSize, const uintptr_t src, size_t srcSize) {
-	ZSTD_outBuffer outBuffer = { (void*)dst, maxDstSize, 0 };
-	ZSTD_inBuffer inBuffer = { (void*)src, srcSize, 0 };
+static void ZSTD_compressStream2_flush(compressStream2_result* result, ZSTD_CCtx* ctx,
+		void* dst, size_t maxDstSize, const void* src, size_t srcSize) {
+	ZSTD_outBuffer outBuffer = { dst, maxDstSize, 0 };
+	ZSTD_inBuffer inBuffer = { src, srcSize, 0 };
 	size_t retCode = ZSTD_compressStream2(ctx, &outBuffer, &inBuffer, ZSTD_e_flush);
 
 	result->return_code = retCode;
@@ -31,9 +32,10 @@ static void ZSTD_compressStream2_flush(compressStream2_result* result, ZSTD_CCtx
 	result->bytes_written = outBuffer.pos;
 }
 
-static void ZSTD_compressStream2_finish(compressStream2_result* result, ZSTD_CCtx* ctx, uintptr_t dst, size_t maxDstSize, const uintptr_t src, size_t srcSize) {
-	ZSTD_outBuffer outBuffer = { (void*)dst, maxDstSize, 0 };
-	ZSTD_inBuffer inBuffer = { (void*)src, srcSize, 0 };
+static void ZSTD_compressStream2_finish(compressStream2_result* result, ZSTD_CCtx* ctx,
+		void* dst, size_t maxDstSize, const void* src, size_t srcSize) {
+	ZSTD_outBuffer outBuffer = { dst, maxDstSize, 0 };
+	ZSTD_inBuffer inBuffer = { src, srcSize, 0 };
 	size_t retCode = ZSTD_compressStream2(ctx, &outBuffer, &inBuffer, ZSTD_e_end);
 
 	result->return_code = retCode;
@@ -48,9 +50,10 @@ typedef struct decompressStream2_result_s {
 	size_t bytes_written;
 } decompressStream2_result;
 
-static void ZSTD_decompressStream_wrapper(decompressStream2_result* result, ZSTD_DCtx* ctx, uintptr_t dst, size_t maxDstSize, const uintptr_t src, size_t srcSize) {
-	ZSTD_outBuffer outBuffer = { (void*)dst, maxDstSize, 0 };
-	ZSTD_inBuffer inBuffer = { (void*)src, srcSize, 0 };
+static void ZSTD_decompressStream_wrapper(decompressStream2_result* result, ZSTD_DCtx* ctx,
+		void* dst, size_t maxDstSize, const void* src, size_t srcSize) {
+	ZSTD_outBuffer outBuffer = { dst, maxDstSize, 0 };
+	ZSTD_inBuffer inBuffer = { src, srcSize, 0 };
 	size_t retCode = ZSTD_decompressStream(ctx, &outBuffer, &inBuffer);
 
 	result->return_code = retCode;
@@ -165,20 +168,19 @@ func (w *Writer) Write(p []byte) (int, error) {
 		srcData = w.srcBuffer
 	}
 
-	srcPtr := C.uintptr_t(uintptr(0)) // Do not point anywhere, if src is empty
+	var srcPtr *byte // Do not point anywhere, if src is empty
 	if len(srcData) > 0 {
-		srcPtr = C.uintptr_t(uintptr(unsafe.Pointer(&srcData[0])))
+		srcPtr = &srcData[0]
 	}
 
 	C.ZSTD_compressStream2_wrapper(
 		w.resultBuffer,
 		w.ctx,
-		C.uintptr_t(uintptr(unsafe.Pointer(&w.dstBuffer[0]))),
+		unsafe.Pointer(&w.dstBuffer[0]),
 		C.size_t(len(w.dstBuffer)),
-		srcPtr,
+		unsafe.Pointer(srcPtr),
 		C.size_t(len(srcData)),
 	)
-	runtime.KeepAlive(p) // Ensure p is kept until here so pointer doesn't disappear during C call
 	ret := int(w.resultBuffer.return_code)
 	if err := getError(ret); err != nil {
 		return 0, err
@@ -221,17 +223,17 @@ func (w *Writer) Flush() error {
 
 	ret := 1 // So we loop at least once
 	for ret > 0 {
-		srcPtr := C.uintptr_t(uintptr(0)) // Do not point anywhere, if src is empty
+		var srcPtr *byte // Do not point anywhere, if src is empty
 		if len(w.srcBuffer) > 0 {
-			srcPtr = C.uintptr_t(uintptr(unsafe.Pointer(&w.srcBuffer[0])))
+			srcPtr = &w.srcBuffer[0]
 		}
 
 		C.ZSTD_compressStream2_flush(
 			w.resultBuffer,
 			w.ctx,
-			C.uintptr_t(uintptr(unsafe.Pointer(&w.dstBuffer[0]))),
+			unsafe.Pointer(&w.dstBuffer[0]),
 			C.size_t(len(w.dstBuffer)),
-			srcPtr,
+			unsafe.Pointer(srcPtr),
 			C.size_t(len(w.srcBuffer)),
 		)
 		ret = int(w.resultBuffer.return_code)
@@ -265,17 +267,17 @@ func (w *Writer) Close() error {
 
 	ret := 1 // So we loop at least once
 	for ret > 0 {
-		srcPtr := C.uintptr_t(uintptr(0)) // Do not point anywhere, if src is empty
+		var srcPtr *byte // Do not point anywhere, if src is empty
 		if len(w.srcBuffer) > 0 {
-			srcPtr = C.uintptr_t(uintptr(unsafe.Pointer(&w.srcBuffer[0])))
+			srcPtr = &w.srcBuffer[0]
 		}
 
 		C.ZSTD_compressStream2_finish(
 			w.resultBuffer,
 			w.ctx,
-			C.uintptr_t(uintptr(unsafe.Pointer(&w.dstBuffer[0]))),
+			unsafe.Pointer(&w.dstBuffer[0]),
 			C.size_t(len(w.dstBuffer)),
-			srcPtr,
+			unsafe.Pointer(srcPtr),
 			C.size_t(len(w.srcBuffer)),
 		)
 		ret = int(w.resultBuffer.return_code)
@@ -445,17 +447,17 @@ func (r *reader) Read(p []byte) (int, error) {
 		src = src[:r.compressionLeft+n]
 
 		// C code
-		srcPtr := C.uintptr_t(uintptr(0)) // Do not point anywhere, if src is empty
+		var srcPtr *byte // Do not point anywhere, if src is empty
 		if len(src) > 0 {
-			srcPtr = C.uintptr_t(uintptr(unsafe.Pointer(&src[0])))
+			srcPtr = &src[0]
 		}
 
 		C.ZSTD_decompressStream_wrapper(
 			r.resultBuffer,
 			r.ctx,
-			C.uintptr_t(uintptr(unsafe.Pointer(&r.decompressionBuffer[0]))),
+			unsafe.Pointer(&r.decompressionBuffer[0]),
 			C.size_t(len(r.decompressionBuffer)),
-			srcPtr,
+			unsafe.Pointer(srcPtr),
 			C.size_t(len(src)),
 		)
 		retCode := int(r.resultBuffer.return_code)

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"os"
 	"runtime/debug"
 	"testing"
 )
@@ -139,6 +140,9 @@ func doStreamCompressionDecompression() error {
 
 func TestStreamCompressionDecompressionParallel(t *testing.T) {
 	// start many goroutines: triggered Cgo stack growth related bugs
+	if os.Getenv("DISABLE_BIG_TESTS") != "" {
+		t.Skip("Big (memory) tests are disabled")
+	}
 	const threads = 500
 	errChan := make(chan error)
 
@@ -165,6 +169,9 @@ func doStreamCompressionStackDepth(stackDepth int) error {
 
 func TestStreamCompressionDecompressionCgoStack(t *testing.T) {
 	// this crashed with: GODEBUG=efence=1 go test .
+	if os.Getenv("DISABLE_BIG_TESTS") != "" {
+		t.Skip("Big (memory) tests are disabled")
+	}
 	const maxStackDepth = 200
 
 	for i := 0; i < maxStackDepth; i++ {

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -114,13 +114,8 @@ func doCompressLevel(payload []byte, out []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed calling CompressLevel: %w", err)
 	}
-
-	orig, err := Decompress(nil, out)
-	if err != nil {
-		return fmt.Errorf("failed calling Decompress: %w", err)
-	}
-	if !bytes.Equal(orig, payload) {
-		return fmt.Errorf("orig=%#v should match payload=%#v", string(orig), string(payload))
+	if len(out) == 0 {
+		return errors.New("CompressLevel must return non-empty bytes")
 	}
 	return nil
 }


### PR DESCRIPTION
The unsafe package says: "Conversion of a uintptr back to Pointer is
not valid in general." This code was violating this rule, by passing
uintptr value to C, which would then interpret them as pointers. This
causes memory corruption: https://github.com/DataDog/zstd/issues/90

This change replaces all uses of uintptr with unsafe.Pointer to avoid
this memory corruption. This has the disadvantage of marking every
argument as escaping to heap. This means the buffers used to call the
zstd functions must be allocated on the heap. I suspect this should
not be a huge problem, since I would expect that high performance
code should already be managing its zstd buffers carefully.

The bug is as follows:

* In zstd_stream_test.go: payload := []byte("Hello World!") is
  marked as "does not escape to heap" (from go test -gcflags -m).
  Therefore, it is allocated on the stack.
* The test calls Writer.Write, which converts the argument to uintptr:
  srcPtr = uintptr(unsafe.Pointer(&srcData[0]))
* Writer.Write then calls Cgo: C.ZSTD_compressStream2_wrapper(...)
* The Go runtime decides the stack needs to be larger, so it copies
  it to a new location.
* (Another thread): The Go runtime decides to reuse the old stack
  location, so it replaces the "Hello World!" bytes with new data.
* (Original thread): Calls zstd, which reads the wrong bytes.

This change adds a test which nearly always crashes for me. While
investigating the other uses of uintptr, I also was able to trigger
a similar crash when calling CompressLevel, but only with:
    GODEBUG=efence=1 go test .

I also added tests for `Ctx.CompressLevel` because it was not
obviously being tested. I did not reproduce this problem with that
function, but I suspect the same bug exists, since it uses the same
pattern.

For a minimal reproduction of this bug, see:
https://github.com/evanj/cgouintptrbug