### PR TITLE
[circleci] Fix 32 bits builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
   "golang-i386":
     docker:
-      - image: toopher/centos-i386:centos6
+      - image: 32bit/ubuntu:16.04
     steps:
       - checkout
       - run: 'linux32 --32bit i386 ./travis_test_32.sh'

--- a/travis_test_32.sh
+++ b/travis_test_32.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Get utilities
-yum -y -q -e 0 install wget tar unzip gcc
+#yum -y -q -e 0 install wget tar unzip gcc
+apt-get -y install wget tar unzip gcc
 
 # Get Go
 wget -q https://dl.google.com/go/go1.13.linux-386.tar.gz

--- a/travis_test_32.sh
+++ b/travis_test_32.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Get utilities
 #yum -y -q -e 0 install wget tar unzip gcc
+apt-get update
 apt-get -y install wget tar unzip gcc
 
 # Get Go


### PR DESCRIPTION
The previous image was using centos6 which got deprecated in November 2020.
It's actually incredibly hard to find 32bits docker images in the wild. This one is a Ubuntu and pass the 32bits tests: https://app.circleci.com/pipelines/github/DataDog/zstd/71/workflows/f7a1455c-af62-47ea-b23c-a297d9132e97/jobs/251