### PR TITLE
[modules] Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/DataDog/zstd
+
+go 1.14


### PR DESCRIPTION
Since we have no external dependancies, the module file is pretty barebone.

"DataDog" is capitalized as is because it is the current github URL, even though github URLs are case-insensitive; talking to GitHub support, it looks like a migration to a different casing (i.e: datadog) is not 100% compatible (i.e: some systems that are case-sensitive for project names could be impact).

Since we always run tests for go version N & N-1 (N being latest), we currently support fully 1.14 as a minimum version.

Fix #89 