### PR TITLE
Fix "Go pointer to Go pointer" panics

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -58,17 +58,25 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		dst = make([]byte, bound)
 	}
 
-	var srcPtr *byte // Do not point anywhere, if src is empty
-	if len(src) > 0 {
-		srcPtr = &src[0]
+	// We need unsafe.Pointer(&src[0]) in the Cgo call to avoid "Go pointer to Go pointer" panics.
+	// This means we need to special case empty input. See:
+	// https://github.com/golang/go/issues/14210#issuecomment-346402945
+	var cWritten C.size_t
+	if len(src) == 0 {
+		cWritten = C.ZSTD_compress(
+			unsafe.Pointer(&dst[0]),
+			C.size_t(len(dst)),
+			unsafe.Pointer(nil),
+			C.size_t(0),
+			C.int(level))
+	} else {
+		cWritten = C.ZSTD_compress(
+			unsafe.Pointer(&dst[0]),
+			C.size_t(len(dst)),
+			unsafe.Pointer(&src[0]),
+			C.size_t(len(src)),
+			C.int(level))
 	}
-
-	cWritten := C.ZSTD_compress(
-		unsafe.Pointer(&dst[0]),
-		C.size_t(len(dst)),
-		unsafe.Pointer(srcPtr),
-		C.size_t(len(src)),
-		C.int(level))
 
 	written := int(cWritten)
 	// Check if the return is an Error code

--- a/zstd_ctx_test.go
+++ b/zstd_ctx_test.go
@@ -65,6 +65,13 @@ func TestCtxCompressLevel(t *testing.T) {
 	}
 }
 
+func TestCtxCompressLevelNoGoPointers(t *testing.T) {
+	testCompressNoGoPointers(t, func(input []byte) ([]byte, error) {
+		cctx := NewCtx()
+		return cctx.CompressLevel(nil, input, BestSpeed)
+	})
+}
+
 func TestCtxEmptySliceCompress(t *testing.T) {
 	ctx := NewCtx()
 

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -168,7 +168,11 @@ func (w *Writer) Write(p []byte) (int, error) {
 		srcData = w.srcBuffer
 	}
 
-	// &srcData[0] is safe: it is p or w.srcBuffer but only if len() > 0 checked above
+	if len(srcData) == 0 {
+		// this is technically unnecessary: srcData is p or w.srcBuffer, and len() > 0 checked above
+		// but this ensures the code can change without dereferencing an srcData[0]
+		return 0, nil
+	}
 	C.ZSTD_compressStream2_wrapper(
 		w.resultBuffer,
 		w.ctx,

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -168,17 +168,13 @@ func (w *Writer) Write(p []byte) (int, error) {
 		srcData = w.srcBuffer
 	}
 
-	var srcPtr *byte // Do not point anywhere, if src is empty
-	if len(srcData) > 0 {
-		srcPtr = &srcData[0]
-	}
-
+	// &srcData[0] is safe: it is p or w.srcBuffer but only if len() > 0 checked above
 	C.ZSTD_compressStream2_wrapper(
 		w.resultBuffer,
 		w.ctx,
 		unsafe.Pointer(&w.dstBuffer[0]),
 		C.size_t(len(w.dstBuffer)),
-		unsafe.Pointer(srcPtr),
+		unsafe.Pointer(&srcData[0]),
 		C.size_t(len(srcData)),
 	)
 	ret := int(w.resultBuffer.return_code)

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -375,6 +375,22 @@ func TestStreamDecompressionChunks(t *testing.T) {
 	}
 }
 
+func TestStreamWriteNoGoPointers(t *testing.T) {
+	testCompressNoGoPointers(t, func(input []byte) ([]byte, error) {
+		buf := &bytes.Buffer{}
+		zw := NewWriter(buf)
+		_, err := zw.Write(input)
+		if err != nil {
+			return nil, err
+		}
+		err = zw.Close()
+		if err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	})
+}
+
 func BenchmarkStreamCompression(b *testing.B) {
 	if raw == nil {
 		b.Fatal(ErrNoPayloadEnv)


### PR DESCRIPTION
The Cgo runtime verifies that Go never passes pointers to other Go
pointers, which is required for correct garbage collection.
Unfortunately, its checks are not perfect, and there are occasional
false positives. Our code triggers these false positives if the
slice passed to compression functions is in the same memory
allocation as Go pointers. This happened when trying to use zstd with
another package's Writer type, which has an internal buffer.

The tests added in this PR all fail with the following panic. The
fix is to ensure the expression unsafe.Pointer(&src[0]) is inside the
Cgo call, and not before. This is documented in the following issue:

https://github.com/golang/go/issues/14210#issuecomment-346402945

The remaining uses of the "var srcPtr *byte" pattern are safe: they
all pass the address of a byte slice that is allocated internally by
this library, so I believe they cannot cause this error.

Fixes the following panic:

```
panic: runtime error: cgo argument has Go pointer to Go pointer

goroutine 30 [running]:
panic(...)
  /usr/local/go/src/runtime/panic.go:969 +0x1b9
github.com/DataDog/zstd.(*ctx).CompressLevel.func1(...)
  /home/circleci/project/zstd_ctx.go:75 +0xd9
github.com/DataDog/zstd.(*ctx).CompressLevel(...)
  /home/circleci/project/zstd_ctx.go:75 +0xce
github.com/DataDog/zstd.TestCtxCompressLevelNoGoPointers.func1(...)
  /home/circleci/project/zstd_ctx_test.go:71 +0x77
github.com/DataDog/zstd.testCompressNoGoPointers(...)
  /home/circleci/project/zstd_test.go:130 +0xad
github.com/DataDog/zstd.TestCtxCompressLevelNoGoPointers(...)
  /home/circleci/project/zstd_ctx_test.go:69 +0x37
testing.tRunner(...)
  /usr/local/go/src/testing/testing.go:1123 +0xef
```