### PR TITLE
add support for legacy zstd >= 0.5

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -1,6 +1,7 @@
 package zstd
 
 /*
+#cgo CFLAGS: -DZSTD_LEGACY_SUPPORT=5
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 */

--- a/zstd_ddict.c
+++ b/zstd_ddict.c
@@ -25,7 +25,7 @@
 #include "zstd_ddict.h"
 
 #if defined(ZSTD_LEGACY_SUPPORT) && (ZSTD_LEGACY_SUPPORT>=1)
-#  include "../legacy/zstd_legacy.h"
+#  include "zstd_legacy.h"
 #endif
 
 

--- a/zstd_decompress.c
+++ b/zstd_decompress.c
@@ -68,7 +68,7 @@
 #include "zstd_decompress_block.h"   /* ZSTD_decompressBlock_internal */
 
 #if defined(ZSTD_LEGACY_SUPPORT) && (ZSTD_LEGACY_SUPPORT>=1)
-#  include "../legacy/zstd_legacy.h"
+#  include "zstd_legacy.h"
 #endif
 
 


### PR DESCRIPTION
The build variable `ZSTD_LEGACY_SUPPORT` controls the support for legacy zsdt formats. It is set to 5 upstream https://github.com/facebook/zstd/blob/a8ecf4ff8826eacc1bbebbc5bd11cf25824cadf5/lib/Makefile#L97 so that the latest zstd lib can decompress older formats from 0.5.

The wrapper however doesn't set this variable so the only support format is the latest from the spec: https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md.


Since we also maintain a 0.5.x branch, it makes sense to set this variable to 5 to make the upgrade to the latest version easier


### Test

- compress "hello world" with the 0.5.x branch

- decompress with cli from upsteam (https://github.com/facebook/zstd/tree/dev/programs#command-line-interface-for-zstandard-library):
```bash
$ ./zstd -d ~/data.zstd -c
hello world%
```
- decompress with current 1.x branch:
```bash
$ ./main ~/data.zstd
2021/05/07 12:49:01 Unknown frame descriptor
```

- decompress with 1.x branch with this patch applied:
```bash
$ ./main ~/data.zstd
hello world%
```
