### PR TITLE
add stub file for dual (cgo & not-cgo) imports working properly

### DIFF
--- a/stub.go
+++ b/stub.go
@@ -1,0 +1,2 @@
+//+build !cgo
+package zstd


### PR DESCRIPTION
When implementing dualstack library (cgo-enabled and disabled should be OK), it is required to have at least 1 file importable, otherwise we can see `go build github.com/DataDog/zstd: build constraints exclude all Go files in ...` error.