### PR TITLE
Add support for building zstd binding against an external libzstd library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,35 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
+  "golang-1.16-external-libzstd":
+    docker:
+      - image: circleci/golang:1.16
+    steps:
+      - checkout
+      - run: 'sudo apt update'
+      - run: 'sudo apt install libzstd-dev'
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build'
+      - run: 'PAYLOAD=`pwd`/mr go test -v'
+      - run: 'PAYLOAD=`pwd`/mr go test -bench .'
   "golang-1.17":
     docker:
       - image: circleci/golang:1.17
     steps:
       - checkout
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build'
+      - run: 'PAYLOAD=`pwd`/mr go test -v'
+      - run: 'PAYLOAD=`pwd`/mr go test -bench .'
+  "golang-1.17-external-libzstd":
+    docker:
+      - image: circleci/golang:1.17
+    steps:
+      - checkout
+      - run: 'sudo apt update'
+      - run: 'sudo apt install libzstd-dev'
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
       - run: 'unzip mr.zip'
       - run: 'go build'
@@ -86,7 +110,9 @@ workflows:
   build:
     jobs:
       - "golang-1.16"
+      - "golang-1.16-external-libzstd"
       - "golang-1.17"
+      - "golang-1.17-external-libzstd"
       - "golang-latest"
       - "golang-latest-external-libzstd"
       - "golang-efence"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,18 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
+  "golang-latest-external-libzstd":
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - checkout
+      - run: 'sudo apt update'
+      - run: 'sudo apt install libzstd-dev'
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build -tags external_libzstd'
+      - run: 'PAYLOAD=`pwd`/mr go test -tags external_libzstd -v'
+      - run: 'PAYLOAD=`pwd`/mr go test -tags external_libzstd -bench .'
   "golang-efence":
     resource_class: xlarge
     docker:
@@ -41,6 +53,18 @@ jobs:
       - run: 'unzip mr.zip'
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr GODEBUG=efence=1 go test -v'
+  "golang-efence-external-libzstd":
+    resource_class: xlarge
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - checkout
+      - run: 'sudo apt update'
+      - run: 'sudo apt install libzstd-dev'
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build -tags external_libzstd'
+      - run: 'PAYLOAD=`pwd`/mr GODEBUG=efence=1 go test -tags external_libzstd -v'
   "golang-zstd-legacy-support":
     docker:
       - image: circleci/golang:latest
@@ -64,6 +88,8 @@ workflows:
       - "golang-1.14"
       - "golang-1.15"
       - "golang-latest"
+      - "golang-latest-external-libzstd"
       - "golang-efence"
+      - "golang-efence-external-libzstd"
       - "golang-i386"
       - "golang-zstd-legacy-support"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 
 jobs:
-  "golang-1.14":
+  "golang-1.16":
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -11,9 +11,9 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
-  "golang-1.15":
+  "golang-1.17":
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -85,8 +85,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - "golang-1.14"
-      - "golang-1.15"
+      - "golang-1.16"
+      - "golang-1.17"
       - "golang-latest"
       - "golang-latest-external-libzstd"
       - "golang-efence"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ There are two main APIs:
 The compress/decompress APIs mirror that of lz4, while the streaming API was
 designed to be a drop-in replacement for zlib.
 
+### Building against an external libzstd
+
+By default, zstd source code is vendored in this repository and the binding will be built with
+the vendored source code bundled.
+
+If you want to build this binding against an external static or shared libzstd library, you can
+use the `external_libzstd` build tag. This will look for the libzstd pkg-config file and extract
+build and linking parameters from that pkg-config file.
+
+Note that it requires at least libzstd 1.4.0.
+
+```bash
+go build -tags external_libzstd
+```
+
 ### Simple `Compress/Decompress`
 
 

--- a/bitstream.h
+++ b/bitstream.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * bitstream
  * Part of FSE library
@@ -461,3 +462,5 @@ MEM_STATIC unsigned BIT_endOfDStream(const BIT_DStream_t* DStream)
 #endif
 
 #endif /* BITSTREAM_H_MODULE */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/compiler.h
+++ b/compiler.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -287,3 +288,5 @@ void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
 #endif
 
 #endif /* ZSTD_COMPILER_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/cover.c
+++ b/cover.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -1244,3 +1245,5 @@ ZDICTLIB_API size_t ZDICT_optimizeTrainFromBuffer_cover(
     return dictSize;
   }
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/cover.h
+++ b/cover.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Facebook, Inc.
  * All rights reserved.
@@ -156,3 +157,5 @@ void COVER_dictSelectionFree(COVER_dictSelection_t selection);
  COVER_dictSelection_t COVER_selectDict(BYTE* customDictContent, size_t dictBufferCapacity,
                        size_t dictContentSize, const BYTE* samplesBuffer, const size_t* samplesSizes, unsigned nbFinalizeSamples,
                        size_t nbCheckSamples, size_t nbSamples, ZDICT_cover_params_t params, size_t* offsets, size_t totalCompressedSize);
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/cpu.h
+++ b/cpu.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Facebook, Inc.
  * All rights reserved.
@@ -211,3 +212,5 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
 #undef X
 
 #endif /* ZSTD_COMMON_CPU_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/debug.c
+++ b/debug.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * debug
  * Part of FSE library
@@ -22,3 +23,5 @@
 #include "debug.h"
 
 int g_debuglevel = DEBUGLEVEL;
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/debug.h
+++ b/debug.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * debug
  * Part of FSE library
@@ -105,3 +106,5 @@ extern int g_debuglevel; /* the variable is only declared,
 #endif
 
 #endif /* DEBUG_H_12987983217 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/divsufsort.c
+++ b/divsufsort.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * divsufsort.c for libdivsufsort-lite
  * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
@@ -1911,3 +1912,5 @@ divbwt(const unsigned char *T, unsigned char *U, int *A, int n, unsigned char * 
 
   return pidx;
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/divsufsort.h
+++ b/divsufsort.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * divsufsort.h for libdivsufsort-lite
  * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
@@ -65,3 +66,5 @@ divbwt(const unsigned char *T, unsigned char *U, int *A, int n, unsigned char * 
 #endif /* __cplusplus */
 
 #endif /* _DIVSUFSORT_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/entropy_common.c
+++ b/entropy_common.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * Common functions of New Generation Entropy library
  * Copyright (c) Yann Collet, Facebook, Inc.
@@ -360,3 +361,5 @@ size_t HUF_readStats_wksp(BYTE* huffWeight, size_t hwSize, U32* rankStats,
     (void)bmi2;
     return HUF_readStats_body_default(huffWeight, hwSize, rankStats, nbSymbolsPtr, tableLogPtr, src, srcSize, workSpace, wkspSize);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/error_private.c
+++ b/error_private.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -54,3 +55,5 @@ const char* ERR_getErrorString(ERR_enum code)
     }
 #endif
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/error_private.h
+++ b/error_private.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -78,3 +79,5 @@ ERR_STATIC const char* ERR_getErrorName(size_t code)
 #endif
 
 #endif /* ERROR_H_MODULE */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,6 @@
 package zstd
 
 /*
-#define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 */
 import "C"

--- a/external_zstd.go
+++ b/external_zstd.go
@@ -1,0 +1,8 @@
+//go:build external_libzstd
+// +build external_libzstd
+
+package zstd
+
+// #cgo CFLAGS: -DUSE_EXTERNAL_ZSTD
+// #cgo pkg-config: libzstd
+import "C"

--- a/external_zstd.go
+++ b/external_zstd.go
@@ -5,4 +5,10 @@ package zstd
 
 // #cgo CFLAGS: -DUSE_EXTERNAL_ZSTD
 // #cgo pkg-config: libzstd
+/*
+#include<zstd.h>
+#if ZSTD_VERSION_NUMBER < 10400
+#error "ZSTD version >= 1.4 is required"
+#endif
+*/
 import "C"

--- a/fastcover.c
+++ b/fastcover.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Facebook, Inc.
  * All rights reserved.
@@ -757,3 +758,5 @@ ZDICT_optimizeTrainFromBuffer_fastCover(
     }
 
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/fse.h
+++ b/fse.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * FSE : Finite State Entropy codec
  * Public Prototypes declaration
@@ -714,3 +715,5 @@ MEM_STATIC unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr)
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/fse_compress.c
+++ b/fse_compress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * FSE : Finite State Entropy encoder
  * Copyright (c) Yann Collet, Facebook, Inc.
@@ -703,3 +704,5 @@ size_t FSE_compress (void* dst, size_t dstCapacity, const void* src, size_t srcS
 #endif
 
 #endif   /* FSE_COMMONDEFS_ONLY */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/fse_decompress.c
+++ b/fse_decompress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * FSE : Finite State Entropy decoder
  * Copyright (c) Yann Collet, Facebook, Inc.
@@ -401,3 +402,5 @@ size_t FSE_decompress(void* dst, size_t dstCapacity, const void* cSrc, size_t cS
 
 
 #endif   /* FSE_COMMONDEFS_ONLY */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/hist.c
+++ b/hist.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * hist : Histogram functions
  * part of Finite State Entropy project
@@ -179,3 +180,5 @@ size_t HIST_count(unsigned* count, unsigned* maxSymbolValuePtr,
     return HIST_count_wksp(count, maxSymbolValuePtr, src, srcSize, tmpCounters, sizeof(tmpCounters));
 }
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/hist.h
+++ b/hist.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * hist : Histogram functions
  * part of Finite State Entropy project
@@ -73,3 +74,5 @@ size_t HIST_countFast_wksp(unsigned* count, unsigned* maxSymbolValuePtr,
  */
 unsigned HIST_count_simple(unsigned* count, unsigned* maxSymbolValuePtr,
                            const void* src, size_t srcSize);
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/huf.h
+++ b/huf.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * huff0 huffman codec,
  * part of Finite State Entropy library
@@ -360,3 +361,5 @@ size_t HUF_readDTableX1_wksp_bmi2(HUF_DTable* DTable, const void* src, size_t sr
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/huf_compress.c
+++ b/huf_compress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * Huffman encoder, part of New Generation Entropy library
  * Copyright (c) Yann Collet, Facebook, Inc.
@@ -935,3 +936,5 @@ size_t HUF_compress (void* dst, size_t maxDstSize, const void* src, size_t srcSi
     return HUF_compress2(dst, maxDstSize, src, srcSize, 255, HUF_TABLELOG_DEFAULT);
 }
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/huf_decompress.c
+++ b/huf_decompress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /* ******************************************************************
  * huff0 huffman decoder,
  * part of Finite State Entropy library
@@ -1349,3 +1350,5 @@ size_t HUF_decompress1X_DCtx(HUF_DTable* dctx, void* dst, size_t dstSize,
                                       workSpace, sizeof(workSpace));
 }
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/mem.h
+++ b/mem.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -422,3 +423,5 @@ MEM_STATIC void MEM_check(void) { DEBUG_STATIC_ASSERT((sizeof(size_t)==4) || (si
 #endif
 
 #endif /* MEM_H_MODULE */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/pool.c
+++ b/pool.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -348,3 +349,5 @@ size_t POOL_sizeof(POOL_ctx* ctx) {
 }
 
 #endif  /* ZSTD_MULTITHREAD */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/pool.h
+++ b/pool.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -82,3 +83,5 @@ int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque);
 #endif
 
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/threading.c
+++ b/threading.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /**
  * Copyright (c) 2016 Tino Reichardt
  * All rights reserved.
@@ -120,3 +121,5 @@ int ZSTD_pthread_cond_destroy(ZSTD_pthread_cond_t* cond)
 }
 
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/threading.h
+++ b/threading.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /**
  * Copyright (c) 2016 Tino Reichardt
  * All rights reserved.
@@ -153,3 +154,5 @@ typedef int ZSTD_pthread_cond_t;
 #endif
 
 #endif /* THREADING_H_938743 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/tools/insert_libzstd_ifdefs.py
+++ b/tools/insert_libzstd_ifdefs.py
@@ -16,7 +16,6 @@ HEADER=f"""#ifndef {FLAG}
 
 ZSTD_H_FOOTER=f"""
 #else /* {FLAG} */
-#undef ZSTD_STATIC_LINKING_ONLY
 #include_next <zstd.h>
 #endif /* {FLAG} */
 """

--- a/tools/insert_libzstd_ifdefs.py
+++ b/tools/insert_libzstd_ifdefs.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+This script rewites the zstd source files to enclose the source code
+inside a #ifndef USE_EXTERNAL_ZSTD.
+
+The goal of that is to avoid compiling vendored zstd source files
+when we compile the library against an externally provided libzstd.
+"""
+import sys
+import glob
+
+FLAG="USE_EXTERNAL_ZSTD"
+
+HEADER=f"""#ifndef {FLAG}
+"""
+
+ZSTD_H_FOOTER=f"""
+#else /* {FLAG} */
+#undef ZSTD_STATIC_LINKING_ONLY
+#include_next <zstd.h>
+#endif /* {FLAG} */
+"""
+
+FOOTER=f"""
+#endif /* {FLAG} */
+"""
+
+def patch_file_content(filename, content):
+    new_content = ""
+    if not content.startswith(HEADER):
+        new_content += HEADER
+    new_content+=content
+    footer = ZSTD_H_FOOTER if filename == "zstd.h" else FOOTER
+    if not content.endswith(footer):
+        new_content += footer
+    return new_content
+
+def insert_ifdefs(file):
+    with open(file, "r") as fd:
+        content=fd.read()
+    with open(file, "w") as fd:
+        fd.write(patch_file_content(file, content))
+
+if __name__ == "__main__":
+    for file in glob.glob("*.c") + glob.glob("*.h"):
+        insert_ifdefs(file)

--- a/xxhash.c
+++ b/xxhash.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  *  xxHash - Fast Hash algorithm
  *  Copyright (c) Yann Collet, Facebook, Inc.
@@ -822,3 +823,5 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 {
     return XXH_readBE64(src);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/xxhash.h
+++ b/xxhash.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * xxHash - Extremely Fast Hash algorithm
  * Header File
@@ -283,3 +284,5 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zdict.c
+++ b/zdict.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -1132,3 +1133,5 @@ size_t ZDICT_addEntropyTablesFromBuffer(void* dictBuffer, size_t dictContentSize
                                                      samplesBuffer, samplesSizes, nbSamples,
                                                      params);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zdict.h
+++ b/zdict.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -450,3 +451,5 @@ size_t ZDICT_addEntropyTablesFromBuffer(void* dictBuffer, size_t dictContentSize
 #endif
 
 #endif   /* DICTBUILDER_H_001 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd.go
+++ b/zstd.go
@@ -1,7 +1,6 @@
 package zstd
 
 /*
-#define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 */
 import "C"

--- a/zstd.h
+++ b/zstd.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -2530,3 +2531,7 @@ ZSTDLIB_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart,
 #if defined (__cplusplus)
 }
 #endif
+#else /* USE_EXTERNAL_ZSTD */
+#undef ZSTD_STATIC_LINKING_ONLY
+#include_next <zstd.h>
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd.h
+++ b/zstd.h
@@ -2532,6 +2532,5 @@ ZSTDLIB_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart,
 }
 #endif
 #else /* USE_EXTERNAL_ZSTD */
-#undef ZSTD_STATIC_LINKING_ONLY
 #include_next <zstd.h>
 #endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_common.c
+++ b/zstd_common.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -81,3 +82,5 @@ void ZSTD_customFree(void* ptr, ZSTD_customMem customMem)
             ZSTD_free(ptr);
     }
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress.c
+++ b/zstd_compress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -6391,3 +6392,5 @@ ZSTD_parameters ZSTD_getParams(int compressionLevel, unsigned long long srcSizeH
     if (srcSizeHint == 0) srcSizeHint = ZSTD_CONTENTSIZE_UNKNOWN;
     return ZSTD_getParams_internal(compressionLevel, srcSizeHint, dictSize, ZSTD_cpm_unknown);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_internal.h
+++ b/zstd_compress_internal.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -1365,3 +1366,5 @@ U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat);
 void ZSTD_CCtx_trace(ZSTD_CCtx* cctx, size_t extraCSize);
 
 #endif /* ZSTD_COMPRESS_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_literals.c
+++ b/zstd_compress_literals.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -156,3 +157,5 @@ size_t ZSTD_compressLiterals (ZSTD_hufCTables_t const* prevHuf,
     DEBUGLOG(5, "Compressed literals: %u -> %u", (U32)srcSize, (U32)(lhSize+cLitSize));
     return lhSize+cLitSize;
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_literals.h
+++ b/zstd_compress_literals.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -27,3 +28,5 @@ size_t ZSTD_compressLiterals (ZSTD_hufCTables_t const* prevHuf,
                         const int bmi2);
 
 #endif /* ZSTD_COMPRESS_LITERALS_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_sequences.c
+++ b/zstd_compress_sequences.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -439,3 +440,5 @@ size_t ZSTD_encodeSequences(
                                         CTable_LitLength, llCodeTable,
                                         sequences, nbSeq, longOffsets);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_sequences.h
+++ b/zstd_compress_sequences.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -52,3 +53,5 @@ size_t ZSTD_fseBitCost(
 size_t ZSTD_crossEntropyCost(short const* norm, unsigned accuracyLog,
                              unsigned const* count, unsigned const max);
 #endif /* ZSTD_COMPRESS_SEQUENCES_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_superblock.c
+++ b/zstd_compress_superblock.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -570,3 +571,5 @@ size_t ZSTD_compressSuperBlock(ZSTD_CCtx* zc,
             zc->bmi2, lastBlock,
             zc->entropyWorkspace, ENTROPY_WORKSPACE_SIZE /* statically allocated in resetCCtx */);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_compress_superblock.h
+++ b/zstd_compress_superblock.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -30,3 +31,5 @@ size_t ZSTD_compressSuperBlock(ZSTD_CCtx* zc,
                                unsigned lastBlock);
 
 #endif /* ZSTD_COMPRESS_ADVANCED_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_ctx.go
+++ b/zstd_ctx.go
@@ -1,7 +1,6 @@
 package zstd
 
 /*
-#define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 */
 import "C"

--- a/zstd_cwksp.h
+++ b/zstd_cwksp.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -660,3 +661,5 @@ MEM_STATIC void ZSTD_cwksp_bump_oversized_duration(
 #endif
 
 #endif /* ZSTD_CWKSP_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_ddict.c
+++ b/zstd_ddict.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -242,3 +243,5 @@ unsigned ZSTD_getDictID_fromDDict(const ZSTD_DDict* ddict)
     if (ddict==NULL) return 0;
     return ZSTD_getDictID_fromDict(ddict->dictContent, ddict->dictSize);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_ddict.h
+++ b/zstd_ddict.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -42,3 +43,5 @@ void ZSTD_copyDDictParameters(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict);
 
 
 #endif /* ZSTD_DDICT_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_decompress.c
+++ b/zstd_decompress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -2165,3 +2166,5 @@ size_t ZSTD_decompressStream_simpleArgs (
     *srcPos = input.pos;
     return cErr;
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_decompress_block.c
+++ b/zstd_decompress_block.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -1546,3 +1547,5 @@ size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx,
     dctx->previousDstEnd = (char*)dst + dSize;
     return dSize;
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_decompress_block.h
+++ b/zstd_decompress_block.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -60,3 +61,5 @@ void ZSTD_buildFSETable(ZSTD_seqSymbol* dt,
 
 
 #endif /* ZSTD_DEC_BLOCK_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_decompress_internal.h
+++ b/zstd_decompress_internal.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -203,3 +204,5 @@ void ZSTD_checkContinuity(ZSTD_DCtx* dctx, const void* dst, size_t dstSize);
 
 
 #endif /* ZSTD_DECOMPRESS_INTERNAL_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_deps.h
+++ b/zstd_deps.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Facebook, Inc.
  * All rights reserved.
@@ -109,3 +110,5 @@
 
 #endif /* ZSTD_DEPS_STDINT */
 #endif /* ZSTD_DEPS_NEED_STDINT */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_double_fast.c
+++ b/zstd_double_fast.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -519,3 +520,5 @@ size_t ZSTD_compressBlock_doubleFast_extDict(
         return ZSTD_compressBlock_doubleFast_extDict_generic(ms, seqStore, rep, src, srcSize, 7);
     }
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_double_fast.h
+++ b/zstd_double_fast.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -36,3 +37,5 @@ size_t ZSTD_compressBlock_doubleFast_extDict(
 #endif
 
 #endif /* ZSTD_DOUBLE_FAST_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_errors.h
+++ b/zstd_errors.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -93,3 +94,5 @@ ZSTDERRORLIB_API const char* ZSTD_getErrorString(ZSTD_ErrorCode code);   /**< Sa
 #endif
 
 #endif /* ZSTD_ERRORS_H_398273423 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_fast.c
+++ b/zstd_fast.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -494,3 +495,5 @@ size_t ZSTD_compressBlock_fast_extDict(
         return ZSTD_compressBlock_fast_extDict_generic(ms, seqStore, rep, src, srcSize, 7);
     }
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_fast.h
+++ b/zstd_fast.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -35,3 +36,5 @@ size_t ZSTD_compressBlock_fast_extDict(
 #endif
 
 #endif /* ZSTD_FAST_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_internal.h
+++ b/zstd_internal.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -488,3 +489,5 @@ size_t ZSTD_decodeSeqHeaders(ZSTD_DCtx* dctx, int* nbSeqPtr,
 #endif
 
 #endif   /* ZSTD_CCOMMON_H_MODULE */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_lazy.c
+++ b/zstd_lazy.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -2182,3 +2183,5 @@ size_t ZSTD_compressBlock_lazy2_extDict_row(
 {
     return ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_rowHash, 2);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_lazy.h
+++ b/zstd_lazy.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -123,3 +124,5 @@ size_t ZSTD_compressBlock_btlazy2_extDict(
 #endif
 
 #endif /* ZSTD_LAZY_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_ldm.c
+++ b/zstd_ldm.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -720,3 +721,5 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     /* Compress the last literals */
     return blockCompressor(ms, seqStore, rep, ip, iend - ip);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_ldm.h
+++ b/zstd_ldm.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -115,3 +116,5 @@ void ZSTD_ldm_adjustParameters(ldmParams_t* params,
 #endif
 
 #endif /* ZSTD_FAST_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_ldm_geartab.h
+++ b/zstd_ldm_geartab.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -101,3 +102,5 @@ static U64 ZSTD_ldm_gearTab[256] = {
 };
 
 #endif /* ZSTD_LDM_GEARTAB_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_legacy.h
+++ b/zstd_legacy.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -413,3 +414,5 @@ MEM_STATIC size_t ZSTD_decompressLegacyStream(void* legacyContext, U32 version,
 #endif
 
 #endif   /* ZSTD_LEGACY_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_opt.c
+++ b/zstd_opt.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Przemyslaw Skibinski, Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -1343,3 +1344,5 @@ size_t ZSTD_compressBlock_btultra_extDict(
 /* note : no btultra2 variant for extDict nor dictMatchState,
  * because btultra2 is not meant to work with dictionaries
  * and is only specific for the first block (no prefix) */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_opt.h
+++ b/zstd_opt.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -54,3 +55,5 @@ size_t ZSTD_compressBlock_btultra_extDict(
 #endif
 
 #endif /* ZSTD_OPT_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -1,7 +1,6 @@
 package zstd
 
 /*
-#define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 
 typedef struct compressStream2_result_s {

--- a/zstd_trace.h
+++ b/zstd_trace.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Facebook, Inc.
  * All rights reserved.
@@ -152,3 +153,5 @@ ZSTD_WEAK_ATTR void ZSTD_trace_decompress_end(
 #endif
 
 #endif /* ZSTD_TRACE_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v01.c
+++ b/zstd_v01.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -2160,3 +2161,5 @@ size_t ZSTDv01_decompressContinue(ZSTDv01_Dctx* dctx, void* dst, size_t maxDstSi
     }
 
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v01.h
+++ b/zstd_v01.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -92,3 +93,5 @@ size_t ZSTDv01_decompressContinue(ZSTDv01_Dctx* dctx, void* dst, size_t maxDstSi
 #endif
 
 #endif /* ZSTD_V01_H_28739879432 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v02.c
+++ b/zstd_v02.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -3520,3 +3521,5 @@ size_t ZSTDv02_decompressContinue(ZSTDv02_Dctx* dctx, void* dst, size_t maxDstSi
 {
     return ZSTD_decompressContinue((ZSTD_DCtx*)dctx, dst, maxDstSize, src, srcSize);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v02.h
+++ b/zstd_v02.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -91,3 +92,5 @@ size_t ZSTDv02_decompressContinue(ZSTDv02_Dctx* dctx, void* dst, size_t maxDstSi
 #endif
 
 #endif /* ZSTD_V02_H_4174539423 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v03.c
+++ b/zstd_v03.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -3162,3 +3163,5 @@ size_t ZSTDv03_decompressContinue(ZSTDv03_Dctx* dctx, void* dst, size_t maxDstSi
 {
     return ZSTD_decompressContinue((ZSTD_DCtx*)dctx, dst, maxDstSize, src, srcSize);
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v03.h
+++ b/zstd_v03.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -91,3 +92,5 @@ size_t ZSTDv03_decompressContinue(ZSTDv03_Dctx* dctx, void* dst, size_t maxDstSi
 #endif
 
 #endif /* ZSTD_V03_H_298734209782 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v04.c
+++ b/zstd_v04.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -3649,3 +3650,5 @@ size_t ZBUFFv04_decompressContinue(ZBUFFv04_DCtx* dctx, void* dst, size_t* maxDs
 
 ZSTD_DCtx* ZSTDv04_createDCtx(void) { return ZSTD_createDCtx(); }
 size_t ZSTDv04_freeDCtx(ZSTD_DCtx* dctx) { return ZSTD_freeDCtx(dctx); }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v04.h
+++ b/zstd_v04.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -140,3 +141,5 @@ size_t ZBUFFv04_recommendedDOutSize(void);
 #endif
 
 #endif /* ZSTD_V04_H_91868324769238 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v05.c
+++ b/zstd_v05.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -4052,3 +4053,5 @@ const char* ZBUFFv05_getErrorName(size_t errorCode) { return ERR_getErrorName(er
 
 size_t ZBUFFv05_recommendedDInSize(void)  { return BLOCKSIZE + ZBUFFv05_blockHeaderSize /* block header size*/ ; }
 size_t ZBUFFv05_recommendedDOutSize(void) { return BLOCKSIZE; }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v05.h
+++ b/zstd_v05.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -160,3 +161,5 @@ size_t ZBUFFv05_recommendedDOutSize(void);
 #endif
 
 #endif  /* ZSTDv0505_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v06.c
+++ b/zstd_v06.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -4156,3 +4157,5 @@ size_t ZBUFFv06_decompressContinue(ZBUFFv06_DCtx* zbd,
 ***************************************/
 size_t ZBUFFv06_recommendedDInSize(void)  { return ZSTDv06_BLOCKSIZE_MAX + ZSTDv06_blockHeaderSize /* block header size*/ ; }
 size_t ZBUFFv06_recommendedDOutSize(void) { return ZSTDv06_BLOCKSIZE_MAX; }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v06.h
+++ b/zstd_v06.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -170,3 +171,5 @@ ZSTDLIBv06_API size_t ZBUFFv06_recommendedDOutSize(void);
 #endif
 
 #endif  /* ZSTDv06_BUFFERED_H */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v07.c
+++ b/zstd_v07.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -4543,3 +4544,5 @@ size_t ZBUFFv07_decompressContinue(ZBUFFv07_DCtx* zbd,
 ***************************************/
 size_t ZBUFFv07_recommendedDInSize(void)  { return ZSTDv07_BLOCKSIZE_ABSOLUTEMAX + ZSTDv07_blockHeaderSize /* block header size*/ ; }
 size_t ZBUFFv07_recommendedDOutSize(void) { return ZSTDv07_BLOCKSIZE_ABSOLUTEMAX; }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstd_v07.h
+++ b/zstd_v07.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -185,3 +186,5 @@ ZSTDLIBv07_API size_t ZBUFFv07_recommendedDOutSize(void);
 #endif
 
 #endif  /* ZSTDv07_H_235446 */
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstdmt_compress.c
+++ b/zstdmt_compress.c
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -1819,3 +1820,5 @@ size_t ZSTDMT_compressStream_generic(ZSTDMT_CCtx* mtctx,
         return remainingToFlush;
     }
 }
+
+#endif /* USE_EXTERNAL_ZSTD */

--- a/zstdmt_compress.h
+++ b/zstdmt_compress.h
@@ -1,3 +1,4 @@
+#ifndef USE_EXTERNAL_ZSTD
 /*
  * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
@@ -108,3 +109,5 @@ ZSTD_frameProgression ZSTDMT_getFrameProgression(ZSTDMT_CCtx* mtctx);
 #endif
 
 #endif   /* ZSTDMT_COMPRESS_H */
+
+#endif /* USE_EXTERNAL_ZSTD */


### PR DESCRIPTION
This is heavily inspired by [the following PR](https://github.com/DataDog/zstd/pull/104/files) from @WGH-

Add the `external_libzstd` tag to be used when we want to build the binding against an externally provided 
zstd library. If the tag is defined, the go build system will look for zstd pkg-config package to gather 
build arguments.

Added CI jobs to run tests and benchmarks with latest go version.