### PR TITLE
[zstd][#60] Add decompression size sanity Check

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -29,6 +29,13 @@ var (
 )
 
 const (
+	// decompressSizeBufferLimit is the limit we set on creating a decompression buffer for the Decompress API
+	// This is made to prevent DOS from maliciously-created payloads (aka zipbomb).
+	// For large payloads with a compression ratio > 10, you can do your own allocation and pass it to the method:
+	// dst := make([]byte, 1GB)
+	// decompressed, err := zstd.Decompress(dst, src)
+	decompressSizeBufferLimit = 1000 * 1000
+
 	zstdFrameHeaderSizeMax = 18 // From zstd.h. Since it's experimental API, hardcoding it
 )
 
@@ -55,8 +62,8 @@ func cCompressBound(srcSize int) int {
 func decompressSizeHint(src []byte) int {
 	// 1 MB or 10x input size
 	upperBound := 10 * len(src)
-	if upperBound < 1000*1000 {
-		upperBound = 1000 * 1000
+	if upperBound < decompressSizeBufferLimit {
+		upperBound = decompressSizeBufferLimit
 	}
 
 	hint := upperBound

--- a/zstd_bulk.go
+++ b/zstd_bulk.go
@@ -15,8 +15,6 @@ var (
 	ErrEmptyDictionary = errors.New("Dictionary is empty")
 	// ErrBadDictionary is returned when cannot load the given dictionary
 	ErrBadDictionary = errors.New("Cannot load dictionary")
-	// ErrContentSize is returned when cannot determine the content size
-	ErrContentSize = errors.New("Cannot determine the content size")
 )
 
 // BulkProcessor implements Bulk processing dictionary API.
@@ -111,12 +109,9 @@ func (p *BulkProcessor) Decompress(dst, src []byte) ([]byte, error) {
 	if len(src) == 0 {
 		return nil, ErrEmptySlice
 	}
-	contentSize := uint64(C.ZSTD_getFrameContentSize(unsafe.Pointer(&src[0]), C.size_t(len(src))))
-	if contentSize == C.ZSTD_CONTENTSIZE_ERROR || contentSize == C.ZSTD_CONTENTSIZE_UNKNOWN {
-		return nil, ErrContentSize
-	}
 
-	if cap(dst) >= int(contentSize) {
+	contentSize := decompressSizeHint(src)
+	if cap(dst) >= contentSize {
 		dst = dst[0:contentSize]
 	} else {
 		dst = make([]byte, contentSize)

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -2,6 +2,7 @@ package zstd
 
 import (
 	"bytes"
+	b64 "encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -281,6 +282,14 @@ func TestLegacy(t *testing.T) {
 				t.Errorf("expected to find %#v; output=%#v", testCase.expected, string(out))
 			}
 		})
+	}
+}
+
+func TestBadPayloadZipBomb(t *testing.T) {
+	payload, _ := b64.StdEncoding.DecodeString("KLUv/dcwMDAwMDAwMDAwMAAA")
+	_, err := Decompress(nil, payload)
+	if err.Error() != "Src size is incorrect" {
+		t.Fatal("zstd should detect that the size is incorrect")
 	}
 }
 


### PR DESCRIPTION
Fix #60 (see for full description).

Previously, we were trusting the input from the zstd header to allocate the memory on `Decompress` API. This meant a carefully crafted payload could make the zstd wrapper allocates an arbitrary size:

```
ᐅ git checkout eaf4b06330d96d58d043f862d1c25f4bc8db7f37
ᐅ go test -v
[...]
--- PASS: TestLegacy (0.00s)
    --- PASS: TestLegacy/0 (0.00s)
    --- PASS: TestLegacy/1 (0.00s)
=== RUN   TestBadPayloadZipBomb
^C
signal: interrupt
FAIL	github.com/DataDog/zstd	82.757s
```
<img width="935" alt="Screen Shot 2022-04-06 at 17 34 53" src="https://user-images.githubusercontent.com/2376565/162075830-4df669fe-921a-4226-bfd3-1344ea61f459.png">
<img width="926" alt="Screen Shot 2022-04-06 at 17 35 00" src="https://user-images.githubusercontent.com/2376565/162075828-0043b38c-9500-4379-b454-8f70a5e16a36.png">

After this fix, we correctly don't allocate too much.
The main part of the change is at: https://github.com/DataDog/zstd/commit/30c4b2986e0ce4fa8ad4b5ee6c1d9d845326d43b#diff-fc46d6feefba07384476b9d2f5a4ae18d6f7322dcd684c388ebe1b2b8d19d394R55-R74

We now basically allocate up to: `min(ZSTD_getFrameContentSize(), max(1MB, 10*input_size))`
