### PR TITLE
[zstd] remove src minimal size limit on `decompressSizeHint`

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -67,6 +67,10 @@ func decompressSizeHint(src []byte) int {
 	}
 
 	hint := int(C.ZSTD_getFrameContentSize(unsafe.Pointer(&src[0]), C.size_t(len(src))))
+	if hint == 0 {
+		// The minimal hint size is 1, beacuse if we return a size with 0, the following access operation will panic with `index out of range`.
+		hint = 1
+	}
 	if hint < 0 { // On error, just use upperBound
 		hint = upperBound
 	}

--- a/zstd.go
+++ b/zstd.go
@@ -66,12 +66,9 @@ func decompressSizeHint(src []byte) int {
 		upperBound = decompressSizeBufferLimit
 	}
 
-	hint := upperBound
-	if len(src) >= zstdFrameHeaderSizeMax {
-		hint = int(C.ZSTD_getFrameContentSize(unsafe.Pointer(&src[0]), C.size_t(len(src))))
-		if hint < 0 { // On error, just use upperBound
-			hint = upperBound
-		}
+	hint := int(C.ZSTD_getFrameContentSize(unsafe.Pointer(&src[0]), C.size_t(len(src))))
+	if hint < 0 { // On error, just use upperBound
+		hint = upperBound
 	}
 
 	// Take the minimum of both


### PR DESCRIPTION
We want to mandate the 'zstd' decompressed data to the buffer pre-allocated by us in some circumstances. (No matter whether its size is smaller than `zstdFrameHeaderSizeMax`.)

For example, in our OLAP system kernel, we have a unified buffer pool to manage all bytes allocated for queries. An accidentally created large array will have a fatal impact on the correctness and performance of the system. (In this case, any compressed data which have a size smaller than 18 would result in a newly constructed byte slice with a size of 1MB, which is intolerable.)

I had also considered other workaround:
- provide a global option to control the manner of binary allocation, the pros are it will make our condition branches simpler, and the cons are the difficulty of this library will get increased, and it will be tricky when different components of a system want different strategies.
- provide a new decompression API, which will break the consistence of our library.
- provide a new arg in the old API, same as point 2.