### PR TITLE
[bulk] Fix being able to Decompress large payloads 

### DIFF
--- a/zstd_bulk.go
+++ b/zstd_bulk.go
@@ -112,12 +112,12 @@ func (p *BulkProcessor) Decompress(dst, src []byte) ([]byte, error) {
 
 	contentSize := decompressSizeHint(src)
 	if cap(dst) >= contentSize {
-		dst = dst[0:contentSize]
+		dst = dst[0:cap(dst)]
 	} else {
 		dst = make([]byte, contentSize)
 	}
 
-	if contentSize == 0 {
+	if len(dst) == 0 {
 		return dst, nil
 	}
 
@@ -125,7 +125,7 @@ func (p *BulkProcessor) Decompress(dst, src []byte) ([]byte, error) {
 	cWritten := C.ZSTD_decompress_usingDDict(
 		dctx,
 		unsafe.Pointer(&dst[0]),
-		C.size_t(contentSize),
+		C.size_t(len(dst)),
 		unsafe.Pointer(&src[0]),
 		C.size_t(len(src)),
 		p.dDict,

--- a/zstd_bullk_test.go
+++ b/zstd_bullk_test.go
@@ -98,7 +98,7 @@ func TestBulkEmptyOrNilDictionary(t *testing.T) {
 	}
 }
 
-func TestBulkCompressEmptyOrNilContent(t *testing.T) {
+func TestBulkCompressDecompressEmptyOrNilContent(t *testing.T) {
 	p := newBulkProcessor(t, dict, BestSpeed)
 	compressed, err := p.Compress(nil, nil)
 	if err != nil {
@@ -114,6 +114,14 @@ func TestBulkCompressEmptyOrNilContent(t *testing.T) {
 	}
 	if len(compressed) < 4 {
 		t.Error("magic number doesn't exist")
+	}
+
+	decompressed, err := p.Decompress(nil, compressed)
+	if err != nil {
+		t.Error("failed to decompress")
+	}
+	if len(decompressed) != 0 {
+		t.Error("content was not decompressed correctly")
 	}
 }
 

--- a/zstd_bullk_test.go
+++ b/zstd_bullk_test.go
@@ -216,7 +216,7 @@ func TestBulkCompressAndDecompressInReverseOrder(t *testing.T) {
 	}
 }
 
-func TestDecompressHighlyCompressable(t *testing.T) {
+func TestBulkDecompressHighlyCompressable(t *testing.T) {
 	p := newBulkProcessor(t, dict, BestSpeed)
 
 	// Generate a big payload


### PR DESCRIPTION
Contrary to [`Decompress`](https://github.com/DataDog/zstd/blob/81cb63ce94277acc3f62cfa5160142f7156cc317/zstd.go#L154), `bulk.Decompress` does not retry with stream decompression on failing to decompress.

https://github.com/DataDog/zstd/pull/115 introduced preventing to allocate buffers that are too big when the provided compressed payload had a potentially malicious zstd buffer (i.e: zipbomb). This had the side-effect that for highly compressed payloads (> 10x), the destination buffer was still resized and would fail.

This fixes the issue and adds a test