### PR TITLE
Add context functions.

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -136,7 +136,6 @@ func CompressLevelCCtx(cctx *CCtx, dst, src []byte, level int) ([]byte, error) {
 	return dst[:written], nil
 }
 
-
 // Compress src into dst.  If you have a buffer to use, you can pass it to
 // prevent allocation.  If it is too small, or if nil is passed, a new buffer
 // will be allocated and returned.


### PR DESCRIPTION
The [docs](https://github.com/facebook/zstd/blob/dev/lib/zstd.h#L253-L255) recommend allocating a context once and reusing this for each compression:

```
 *  When compressing many times,
 *  it is recommended to allocate a context just once,
 *  and reuse it for each successive compression operation.
```

We have just started using this library in the Datadog agent. Since the agent will be compressing *a lot* I feel it would make sense to expose and use these functions so that we don't have to allocate and free the context with each call.

There is a bunch of code duplication here - I've just copied the existing functions. Let me know if you would prefer to share the code and I will make the changes accordingly.