### PR TITLE
zstd_stream.go: remove intermediate source buffer for Writer.

### DIFF
--- a/zstd_small_stream_test.go
+++ b/zstd_small_stream_test.go
@@ -1,0 +1,102 @@
+package zstd
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkSmallWriteStreamCompression(b *testing.B) {
+	randbs := func(n int) []byte {
+		bs := make([]byte, n)
+		r, err := rand.Read(bs)
+		if err != nil {
+			b.Fatalf("Failed to generate random bytes for benchmark: %v", err)
+		}
+		if r < n {
+			b.Fatalf("Read %d bytes, less than requested %d", r, n)
+		}
+		return bs
+	}
+
+	count := func(n int) []byte {
+		bs := make([]byte, n)
+		for i := 0; i < n; i++ {
+			bs[i] = byte(n % 255)
+		}
+		return bs
+	}
+
+	for _, tt := range []struct {
+		name   string
+		rawgen func(n int) []byte
+	}{
+		{
+			name:   "all-zeros",
+			rawgen: func(n int) []byte { return make([]byte, n) },
+		},
+		{
+			name:   "count",
+			rawgen: count,
+		},
+		{
+			name:   "random",
+			rawgen: randbs,
+		},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			raw := tt.rawgen(b.N)
+			var intermediate bytes.Buffer
+			w := NewWriter(&intermediate)
+			b.SetBytes(1)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := w.Write(raw[i : i+1])
+				if err != nil {
+					b.Fatalf("Failed writing to compress object: %s", err)
+				}
+			}
+			w.Close()
+			b.ReportMetric(float64(intermediate.Len())/float64(b.N), "compressed_bytes/op")
+		})
+
+	}
+}
+
+func TestSmallWriteStreaming(t *testing.T) {
+	b := &bytes.Buffer{}
+	for i := 0; i < 5000; i++ {
+		b.Write([]byte("Hello World! "))
+	}
+	data1 := b.Bytes()
+
+	// Compress 1
+	buffer1 := &bytes.Buffer{}
+	w1 := NewWriterLevel(buffer1, BestSpeed)
+	_, err := w1.Write(data1)
+	if err != nil {
+		t.Fatalf("Failed to write data: %v", err)
+	}
+	err = w1.Close()
+	if err != nil {
+		t.Fatalf("Failed to close writer: %v", err)
+	}
+
+	// Compress 2
+	buffer2 := &bytes.Buffer{}
+	w2 := NewWriterLevel(buffer2, BestSpeed)
+	for i := 0; i < 5000; i++ {
+		_, err := w2.Write([]byte("Hello World! "))
+		if err != nil {
+			t.Fatalf("Failed to write data: %v", err)
+		}
+	}
+	err = w2.Close()
+	if err != nil {
+		t.Fatalf("Failed to close writer: %v", err)
+	}
+
+	if buffer1.Len() != buffer2.Len() {
+		t.Errorf("expected unbuffered writes to use same amount of space as buffered writes.\n")
+	}
+}

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -80,7 +80,6 @@ type Writer struct {
 
 	ctx              *C.ZSTD_CCtx
 	dict             []byte
-	srcBuffer        []byte
 	dstBuffer        []byte
 	firstError       error
 	underlyingWriter io.Writer
@@ -138,7 +137,6 @@ func NewWriterLevelDict(w io.Writer, level int, dict []byte) *Writer {
 		CompressionLevel: level,
 		ctx:              ctx,
 		dict:             dict,
-		srcBuffer:        make([]byte, 0),
 		dstBuffer:        make([]byte, CompressBound(1024)),
 		firstError:       err,
 		underlyingWriter: w,
@@ -154,65 +152,59 @@ func (w *Writer) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+	total := len(p)
 	// Check if dstBuffer is enough
 	w.dstBuffer = w.dstBuffer[0:cap(w.dstBuffer)]
 	if len(w.dstBuffer) < CompressBound(len(p)) {
 		w.dstBuffer = make([]byte, CompressBound(len(p)))
 	}
 
-	// Do not do an extra memcopy if zstd ingest all input data
-	srcData := p
-	fastPath := len(w.srcBuffer) == 0
-	if !fastPath {
-		w.srcBuffer = append(w.srcBuffer, p...)
-		srcData = w.srcBuffer
-	}
+	dstoff := 0
+	consumed := 0
+	for len(p) > 0 {
+		C.ZSTD_compressStream2_wrapper(
+			w.resultBuffer,
+			w.ctx,
+			unsafe.Pointer(&w.dstBuffer[dstoff]),
+			C.size_t(len(w.dstBuffer[dstoff:])),
+			unsafe.Pointer(&p[0]),
+			C.size_t(len(p)),
+		)
+		ret := int(w.resultBuffer.return_code)
+		if err := getError(ret); err != nil {
+			// The stream is dead after this.
+			w.firstError = err
+			return 0, err
+		}
+		p = p[w.resultBuffer.bytes_consumed:]
+		dstoff += int(w.resultBuffer.bytes_written)
+		consumed += int(w.resultBuffer.bytes_consumed)
+		if len(p) > 0 && dstoff == len(w.dstBuffer) {
+			// We have bytes remaining to compress and our output buffer
+			// filled up. This shouldn't happen since we calculated it
+			// in advance using CompressBound, but we need to handle it
+			// in case there was some miscalculation, or the internal
+			// stream buffer contained enough data from previous writes
+			// to overflow dstBuffer. (it's not clear from the docs
+			// whether this is possible)
+			//
+			// Allocate space for whatever we haven't compressed yet.
+			newbuf := make([]byte, len(w.dstBuffer)+CompressBound(total-consumed))
+			copy(newbuf, w.dstBuffer)
+			w.dstBuffer = newbuf
 
-	if len(srcData) == 0 {
-		// this is technically unnecessary: srcData is p or w.srcBuffer, and len() > 0 checked above
-		// but this ensures the code can change without dereferencing an srcData[0]
-		return 0, nil
-	}
-	C.ZSTD_compressStream2_wrapper(
-		w.resultBuffer,
-		w.ctx,
-		unsafe.Pointer(&w.dstBuffer[0]),
-		C.size_t(len(w.dstBuffer)),
-		unsafe.Pointer(&srcData[0]),
-		C.size_t(len(srcData)),
-	)
-	ret := int(w.resultBuffer.return_code)
-	if err := getError(ret); err != nil {
-		return 0, err
-	}
-
-	consumed := int(w.resultBuffer.bytes_consumed)
-	if !fastPath {
-		w.srcBuffer = w.srcBuffer[consumed:]
-	} else {
-		remaining := len(p) - consumed
-		if remaining > 0 {
-			// We still have some non-consumed data, copy remaining data to srcBuffer
-			// Try to not reallocate w.srcBuffer if we already have enough space
-			if cap(w.srcBuffer) >= remaining {
-				w.srcBuffer = w.srcBuffer[0:remaining]
-			} else {
-				w.srcBuffer = make([]byte, remaining)
-			}
-			copy(w.srcBuffer, p[consumed:])
 		}
 	}
 
-	written := int(w.resultBuffer.bytes_written)
 	// Write to underlying buffer
-	_, err := w.underlyingWriter.Write(w.dstBuffer[:written])
+	_, err := w.underlyingWriter.Write(w.dstBuffer[:dstoff])
 
 	// Same behaviour as zlib, we can't know how much data we wrote, only
 	// if there was an error
 	if err != nil {
 		return 0, err
 	}
-	return len(p), err
+	return total, err
 }
 
 // Flush writes any unwritten data to the underlying io.Writer.
@@ -223,24 +215,18 @@ func (w *Writer) Flush() error {
 
 	ret := 1 // So we loop at least once
 	for ret > 0 {
-		var srcPtr *byte // Do not point anywhere, if src is empty
-		if len(w.srcBuffer) > 0 {
-			srcPtr = &w.srcBuffer[0]
-		}
-
 		C.ZSTD_compressStream2_flush(
 			w.resultBuffer,
 			w.ctx,
 			unsafe.Pointer(&w.dstBuffer[0]),
 			C.size_t(len(w.dstBuffer)),
-			unsafe.Pointer(srcPtr),
-			C.size_t(len(w.srcBuffer)),
+			unsafe.Pointer(uintptr(0)),
+			C.size_t(0),
 		)
 		ret = int(w.resultBuffer.return_code)
 		if err := getError(ret); err != nil {
 			return err
 		}
-		w.srcBuffer = w.srcBuffer[w.resultBuffer.bytes_consumed:]
 		written := int(w.resultBuffer.bytes_written)
 		_, err := w.underlyingWriter.Write(w.dstBuffer[:written])
 		if err != nil {
@@ -267,24 +253,18 @@ func (w *Writer) Close() error {
 
 	ret := 1 // So we loop at least once
 	for ret > 0 {
-		var srcPtr *byte // Do not point anywhere, if src is empty
-		if len(w.srcBuffer) > 0 {
-			srcPtr = &w.srcBuffer[0]
-		}
-
 		C.ZSTD_compressStream2_finish(
 			w.resultBuffer,
 			w.ctx,
 			unsafe.Pointer(&w.dstBuffer[0]),
 			C.size_t(len(w.dstBuffer)),
-			unsafe.Pointer(srcPtr),
-			C.size_t(len(w.srcBuffer)),
+			unsafe.Pointer(uintptr(0)),
+			C.size_t(0),
 		)
 		ret = int(w.resultBuffer.return_code)
 		if err := getError(ret); err != nil {
 			return err
 		}
-		w.srcBuffer = w.srcBuffer[w.resultBuffer.bytes_consumed:]
 		written := int(w.resultBuffer.bytes_written)
 		_, err := w.underlyingWriter.Write(w.dstBuffer[:written])
 		if err != nil {


### PR DESCRIPTION
The Writer was using an intermediate source buffer, which could sometimes buffer input bytes until the next Write, Flush, or Close call. This is not necessary, complicates the code, and can cause a performance hit.

This commit eliminates the source buffer and its overhead, instead ensuring that all input bytes are compressed when Write returns.

In practice the intermediate source buffer should never or almost never have been used, so this is mostly beneficial for simplifying the code, although we do see a memory usage improvement in the benchmarks

```
name                    old time/op    new time/op    delta
StreamCompression-16      57.9ms ± 5%    56.7ms ± 5%    ~     (p=0.165 n=10+10)

name                    old speed      new speed      delta
StreamCompression-16    1.81GB/s ± 5%  1.85GB/s ± 5%    ~     (p=0.165 n=10+10)

name                    old alloc/op   new alloc/op   delta
StreamCompression-16      2.19MB ± 7%    2.07MB ± 6%  -5.45%  (p=0.001 n=10+10)

name                    old allocs/op  new allocs/op  delta
StreamCompression-16        3.00 ± 0%      3.00 ± 0%    ~     (all equal)
```