### PR TITLE
add Ctx.DecompressInto for decompression of payloads with known sizes

### DIFF
--- a/zstd_ctx_test.go
+++ b/zstd_ctx_test.go
@@ -118,6 +118,36 @@ func TestCtxDecompressZeroLengthBuf(t *testing.T) {
 	}
 }
 
+func TestCtxCompressDecompressInto(t *testing.T) {
+	ctx := NewCtx()
+	payload := []byte("Hello World!")
+	compressed, err := ctx.Compress(make([]byte, CompressBound(len(payload))), payload)
+	if err != nil {
+		t.Fatalf("Error while compressing: %v", err)
+	}
+	t.Logf("Compressed: %v", compressed)
+
+	// We know the size of the payload; construct a buffer that perfectly fits
+	// the payload and use DecompressInto.
+	decompressed := make([]byte, len(payload))
+	if n, err := ctx.DecompressInto(decompressed, compressed); err != nil {
+		t.Fatalf("error while decompressing into buffer of size %d: %v",
+			len(decompressed), err)
+	} else if n != len(decompressed) {
+		t.Errorf("Ctx.DecompressedInto = (%d, nil), want (%d, nil)", n, len(decompressed))
+	}
+	if !bytes.Equal(payload, decompressed) {
+		t.Fatalf("Ctx.DecompressInto(_, Ctx.Compress(_, %q)) yielded %q, want %q", payload, decompressed, payload)
+	}
+
+	// Ensure that decompressing into a buffer too small errors appropriately.
+	smallBuffer := make([]byte, len(payload)-1)
+	if _, err := ctx.DecompressInto(smallBuffer, compressed); !IsDstSizeTooSmallError(err) {
+		t.Fatalf("Ctx.DecompressInto(<%d-sized buffer>, Ctx.Compress(_, %q)) = %v, want 'Destination buffer is too small'",
+			len(smallBuffer), payload, err)
+	}
+}
+
 func TestCtxTooSmall(t *testing.T) {
 	ctx := NewCtx()
 


### PR DESCRIPTION
Adds DecompressInto() to zstd_context to match the functionality previously implemented in the zstd file.

In some systems, compressed payloads are prefixed or tagged with the size of the original payload. This allows allocation of a perfectly-sized buffer to hold the decompressed payload. This method provides a way to decompress directly into a pre-allocated buffer.

DecompressInto accepts a destination buffer and requires that the decompressed payload fit into the buffer. If it does not, it returns the original error returned by zstd.

Relates to/Follows up on: https://github.com/DataDog/zstd/pull/130