### PR TITLE
Keep decompressing as long as we have compressed data

### DIFF
--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -355,6 +355,7 @@ type reader struct {
 	decompressionBuffer []byte
 	decompOff           int
 	decompSize          int
+	remainingBytes      int
 	dict                []byte
 	firstError          error
 	recommendedSrcSize  int
@@ -447,12 +448,12 @@ func (r *reader) Read(p []byte) (int, error) {
 	// at least one zstd block, so that we don't block if the
 	// other end has flushed a block.
 	for {
-		// - If the last decompression didn't entirely fill the decompression buffer,
-		//   zstd flushed all it could, and needs new data. In that case, do 1 Read.
-		// - If the last decompression did entirely fill the decompression buffer,
-		//   it might have needed more room to decompress the input. In that case,
-		//   don't do any unnecessary Read that might block.
-		needsData := r.decompSize < len(r.decompressionBuffer)
+		// Do a read only when zstd doesn't have any pending output. When zstd could
+		// not finish writing output, it will keep input buffer non-empty.
+		// https://github.com/facebook/zstd/commit/b3060f7a9ea3555c6045606be58dddc86bbb099b
+		// > when all compressed frame is consumed, it means decompression is completed,
+		// > with regenerated data fully flushed.
+		needsData := r.compressionLeft == 0
 
 		var src []byte
 		if !needsData {
@@ -468,16 +469,16 @@ func (r *reader) Read(p []byte) (int, error) {
 			if err != nil && err != io.EOF { // Handle underlying reader errors first
 				return 0, fmt.Errorf("failed to read from underlying reader: %w", err)
 			}
-			if n == 0 {
-				// Ideally, we'd return with ErrUnexpectedEOF in all cases where the stream was unexpectedly EOF'd
-				// during a block or frame, i.e. when there are incomplete, pending compression data.
-				// However, it's hard to detect those cases with zstd. Namely, there is no way to know the size of
-				// the current buffered compression data in the zstd stream internal buffers.
-				// Best effort: throw ErrUnexpectedEOF if we still have some pending buffered compression data that
-				// zstd doesn't want to accept.
-				// If we don't have any buffered compression data but zstd still has some in its internal buffers,
-				// we will return with EOF instead.
-				if r.compressionLeft > 0 {
+
+			// Only return EOF when we have no more compressed data to
+			// decompress and no more input is coming.
+			// From ZSTD_decompressStream docs:
+			// If `input.pos < input.size`, some input has not been consumed.
+			// It's up to the caller to present again remaining data.
+			if n == 0 && r.compressionLeft == 0 {
+				// Last call to ZSTD_decompressStream indicated that
+				// it needs more data, but we're not getting any.
+				if r.remainingBytes > 0 {
 					return 0, io.ErrUnexpectedEOF
 				}
 				return 0, io.EOF
@@ -516,7 +517,7 @@ func (r *reader) Read(p []byte) (int, error) {
 		r.compressionLeft = len(src) - bytesConsumed
 		r.decompSize = int(r.resultBuffer.bytes_written)
 		r.decompOff = copy(p, r.decompressionBuffer[:r.decompSize])
-
+		r.remainingBytes = retCode
 		// Resize buffers
 		nsize := retCode // Hint for next src buffer size
 		if nsize <= 0 {

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -460,3 +460,53 @@ func BenchmarkStreamDecompression(b *testing.B) {
 		r.Close()
 	}
 }
+
+func TestStreamConcat(t *testing.T) {
+	totalSize := 64
+	r := NewRandBytes()
+	rawData1 := make([]byte, totalSize)
+	r.Read(rawData1)
+	rawData2 := make([]byte, totalSize)
+	r.Read(rawData2)
+
+	expected := make([]byte, totalSize * 2)
+	copy(expected, rawData1)
+	copy(expected[totalSize:], rawData2)
+
+	compressed1, _ := Compress(nil, rawData1)
+	compressed2, _ := Compress(nil, rawData2)
+
+	combined := make([]byte, len(compressed1) + len(compressed2))
+	copy(combined, compressed1)
+	copy(combined[len(compressed1):], compressed2)
+
+	decompressed, _ := Decompress(nil, combined)
+	if !bytes.Equal(decompressed, expected) {
+		t.Error("Decompress should handle concatenated streams")
+	}
+
+	reader := NewReader(bytes.NewBuffer(combined))
+	decompressed, err := ioutil.ReadAll(reader)
+	failOnError(t, "stream decompress failed", err)
+
+	if !bytes.Equal(decompressed, expected) {
+		t.Error("stream decompress failed to produce expecteed bytes")
+	}
+}
+
+func TestUnexpectedEOF(t *testing.T) {
+	totalSize := 64
+	r := NewRandBytes()
+	rawData := make([]byte, totalSize)
+	r.Read(rawData)
+
+	compressed, _ := Compress(nil, rawData)
+	compressed = compressed[:len(compressed)-1]
+
+	reader := NewReader(bytes.NewBuffer(compressed))
+	_, err := ioutil.ReadAll(reader)
+
+	if err != io.ErrUnexpectedEOF {
+		t.Error("stream decompress failed to detect unexpected end of input")
+	}
+}


### PR DESCRIPTION
ZSTD_decompressStream may consume only part of the src buffer, for example if the input is a concatenation of two compressed streams. In this case the second stream will remain undecoded in the input buffer after the first call, and we need to call decompress routine again.

This makes NewReader behavior closer to Decompress, that handles such concatenated streams transparently.