### PR TITLE
Bump minimum Go version to 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,9 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
-  "golang-latest":
+  "golang-1.26":
     docker:
-      - image: cimg/go:latest
+      - image: cimg/go:1.26
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -55,9 +55,9 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
-  "golang-latest-external-libzstd":
+  "golang-1.26-external-libzstd":
     docker:
-      - image: cimg/go:latest
+      - image: cimg/go:1.26
     steps:
       - checkout
       - run: 'sudo apt update'
@@ -70,7 +70,7 @@ jobs:
   "golang-efence":
     resource_class: xlarge
     docker:
-      - image: cimg/go:latest
+      - image: cimg/go:1.26
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -80,7 +80,7 @@ jobs:
   "golang-efence-external-libzstd":
     resource_class: xlarge
     docker:
-      - image: cimg/go:latest
+      - image: cimg/go:1.26
     steps:
       - checkout
       - run: 'sudo apt update'
@@ -104,8 +104,8 @@ workflows:
       - "golang-1.24-external-libzstd"
       - "golang-1.25"
       - "golang-1.25-external-libzstd"
-      - "golang-latest"
-      - "golang-latest-external-libzstd"
+      - "golang-1.26"
+      - "golang-1.26-external-libzstd"
       - "golang-efence"
       - "golang-efence-external-libzstd"
       - "golang-i386"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 
 jobs:
-  "golang-1.19":
+  "golang-1.24":
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.24
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -11,9 +11,9 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
-  "golang-1.19-external-libzstd":
+  "golang-1.24-external-libzstd":
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.24
     steps:
       - checkout
       - run: 'sudo apt update'
@@ -23,9 +23,9 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
-  "golang-1.20":
+  "golang-1.25":
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.25
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -33,9 +33,31 @@ jobs:
       - run: 'go build'
       - run: 'PAYLOAD=`pwd`/mr go test -v'
       - run: 'PAYLOAD=`pwd`/mr go test -bench .'
-  "golang-1.20-external-libzstd":
+  "golang-1.25-external-libzstd":
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.25
+    steps:
+      - checkout
+      - run: 'sudo apt update'
+      - run: 'sudo apt install libzstd-dev'
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build'
+      - run: 'PAYLOAD=`pwd`/mr go test -v'
+      - run: 'PAYLOAD=`pwd`/mr go test -bench .'
+  "golang-latest":
+    docker:
+      - image: cimg/go:latest
+    steps:
+      - checkout
+      - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
+      - run: 'unzip mr.zip'
+      - run: 'go build'
+      - run: 'PAYLOAD=`pwd`/mr go test -v'
+      - run: 'PAYLOAD=`pwd`/mr go test -bench .'
+  "golang-latest-external-libzstd":
+    docker:
+      - image: cimg/go:latest
     steps:
       - checkout
       - run: 'sudo apt update'
@@ -48,7 +70,7 @@ jobs:
   "golang-efence":
     resource_class: xlarge
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:latest
     steps:
       - checkout
       - run: 'wget https://github.com/DataDog/zstd/files/2246767/mr.zip'
@@ -58,7 +80,7 @@ jobs:
   "golang-efence-external-libzstd":
     resource_class: xlarge
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:latest
     steps:
       - checkout
       - run: 'sudo apt update'
@@ -78,10 +100,12 @@ workflows:
   version: 2
   build:
     jobs:
-      - "golang-1.19"
-      - "golang-1.19-external-libzstd"
-      - "golang-1.20"
-      - "golang-1.20-external-libzstd"
+      - "golang-1.24"
+      - "golang-1.24-external-libzstd"
+      - "golang-1.25"
+      - "golang-1.25-external-libzstd"
+      - "golang-latest"
+      - "golang-latest-external-libzstd"
       - "golang-efence"
       - "golang-efence-external-libzstd"
       - "golang-i386"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/zstd
 
-go 1.14
+go 1.24


### PR DESCRIPTION
## Summary
- Bump `go.mod` minimum Go version from 1.14 to 1.24 (2 major versions behind)
- Replace CircleCI Go 1.19/1.20 jobs with Go 1.24, 1.25, and 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)