### PR TITLE
Decompress: grow from a small buffer for unknown-size frames with no dst

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -145,14 +145,18 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	hint, foundHint := decompressSizeHint(src)
 
 	// Reuse the caller buffer when it is large enough, or when the size is
-	// unknown (the hint is then only an upper bound); otherwise allocate the hint.
+	// unknown (the hint is then only an upper bound). Otherwise size from the
+	// hint, or grow from a small buffer when the size is unknown and none was
+	// supplied (see growDecompress).
 	switch {
 	case cap(dst) >= hint:
 		dst = dst[:cap(dst)]
 	case !foundHint && cap(dst) > 0:
 		dst = dst[:cap(dst)]
-	default:
+	case foundHint:
 		dst = make([]byte, hint)
+	default:
+		return growDecompress(src, DecompressInto)
 	}
 
 	written, err := DecompressInto(dst, src)
@@ -164,6 +168,31 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	}
 
 	// We failed getting a dst buffer of correct size, use stream API
+	r := NewReader(bytes.NewReader(src))
+	defer r.Close()
+	return ioutil.ReadAll(r)
+}
+
+// growDecompress decompresses src when the frame does not advertise its size and
+// no caller buffer was supplied. It starts small and grows on demand (3x, 6x,
+// 12x the compressed size) before falling back to the streaming reader, so it
+// never allocates the pessimistic decompressSizeBufferLimit bound up front and
+// only ever sizes from the input length, not an attacker-controlled field.
+func growDecompress(src []byte, into func(dst, src []byte) (int, error)) ([]byte, error) {
+	dst := make([]byte, len(src)*3)
+	for attempt := 0; attempt < 3; attempt++ {
+		written, err := into(dst, src)
+		if err == nil {
+			return dst[:written], nil
+		}
+		if !IsDstSizeTooSmallError(err) {
+			return nil, err
+		}
+		if attempt < 2 {
+			dst = make([]byte, len(dst)*2)
+		}
+	}
+
 	r := NewReader(bytes.NewReader(src))
 	defer r.Close()
 	return ioutil.ReadAll(r)

--- a/zstd_ctx.go
+++ b/zstd_ctx.go
@@ -118,8 +118,10 @@ func (c *ctx) Decompress(dst, src []byte) ([]byte, error) {
 		dst = dst[:cap(dst)]
 	case !foundHint && cap(dst) > 0:
 		dst = dst[:cap(dst)]
-	default:
+	case foundHint:
 		dst = make([]byte, hint)
+	default:
+		return growDecompress(src, c.DecompressInto)
 	}
 
 	written, err := c.DecompressInto(dst, src)

--- a/zstd_nil_buffer_test.go
+++ b/zstd_nil_buffer_test.go
@@ -1,0 +1,54 @@
+package zstd
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestDecompressNilBufferUnknownSizeAvoidsBound verifies that decompressing an
+// unknown-size frame with no caller buffer grows from a small size instead of
+// allocating decompressSizeBufferLimit (the pessimistic upper bound).
+func TestDecompressNilBufferUnknownSizeAvoidsBound(t *testing.T) {
+	payload := bytes.Repeat([]byte("datadog-"), 525) // 4200 bytes, well under 1 MB
+	frame := unknownSizeFrame(t, payload)
+
+	for _, d := range decompressors() {
+		t.Run(d.name, func(t *testing.T) {
+			out, err := d.fn(nil, frame)
+			if err != nil {
+				t.Fatalf("decompress: %v", err)
+			}
+			if !bytes.Equal(out, payload) {
+				t.Fatalf("round-trip mismatch")
+			}
+			if cap(out) >= decompressSizeBufferLimit {
+				t.Fatalf("nil-buffer unknown-size decode allocated the bound (cap %d)", cap(out))
+			}
+		})
+	}
+}
+
+// TestDecompressNilBufferKnownSizeExact verifies the known-size path is
+// unaffected: a nil buffer is still sized to the exact content size.
+func TestDecompressNilBufferKnownSizeExact(t *testing.T) {
+	payload := bytes.Repeat([]byte("datadog-"), 525)
+	frame, err := Compress(nil, payload)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+
+	for _, d := range decompressors() {
+		t.Run(d.name, func(t *testing.T) {
+			out, err := d.fn(nil, frame)
+			if err != nil {
+				t.Fatalf("decompress: %v", err)
+			}
+			if !bytes.Equal(out, payload) {
+				t.Fatalf("round-trip mismatch")
+			}
+			if cap(out) != len(payload) {
+				t.Fatalf("known-size nil decode should allocate exactly: cap %d want %d", cap(out), len(payload))
+			}
+		})
+	}
+}


### PR DESCRIPTION
> **Stacked on #168** (base branch `kris.kennaway/decompress-reuse-caller-buffer`). Review/merge #168 first; this PR's diff is just the final commit. It's split out so it can be accepted or rejected independently.

## Problem

For frames that do **not** advertise their decompressed size — legacy zstd v0.5 frames, and streaming frames compressed without a pledged source size — `decompressSizeHint` returns only a pessimistic upper bound (`max(50×len(src), decompressSizeBufferLimit)` = at least 1 MB). #168 fixed the case where the caller passes a reusable buffer. This PR handles the remaining case: **`Decompress(nil, src)` / no caller buffer**, where the code still allocates that ≥1 MB bound up front on every such decode regardless of the real payload size.

## Fix

When the size is unknown and no caller buffer is supplied, grow from `3×len(src)` (`3× → 6× → 12×`) before falling back to the streaming reader, instead of allocating the bound. The size-hint fast path (frames that advertise their size) is unchanged.

## History note

This restores the sizing used before **489b911 "Remove Decompress multiple retries."** That commit dropped the grow loop on the premise that *"zstd 1.3.0+ frames always carry a size hint."* That premise does not hold for legacy v0.5 frames or unpledged streaming frames — exactly the case handled here — so the retries weren't evaluated against it. This reintroduces the grow schedule **only** for the unknown-size + no-buffer path, leaving the 1.3.0+ hint optimization intact.

No DoS regression vs **30c4b29 "Add a sanity limit"**: `growDecompress` never allocates based on an attacker-claimed size (only from the input length, bounded to ≤12×`len(src)`), so it does not reintroduce the unbounded-allocation vector that `decompressSizeBufferLimit` guards. (The streaming fallback's `ReadAll` is unbounded, but that already exists on the current code path.)

Applies to both `Decompress` and `ctx.Decompress`; regression tests (nil-buffer unknown-size avoids the bound; multi-block stream fallback; known-size still exact) run as subtests against both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
